### PR TITLE
Don't reset buffers in Write (fixes #81)

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -192,9 +192,6 @@ func (ch *conn) InsertWithOption(
 	if err != nil {
 		return err
 	}
-	for _, col := range columns {
-		col.Reset()
-	}
 	return nil
 }
 

--- a/insert.go
+++ b/insert.go
@@ -192,6 +192,9 @@ func (ch *conn) InsertWithOption(
 	if err != nil {
 		return err
 	}
+	for _, col := range columns {
+		col.Reset()
+	}
 	return nil
 }
 

--- a/insert.go
+++ b/insert.go
@@ -162,9 +162,6 @@ func (s *insertStmt) Write(ctx context.Context, columns ...column.ColumnBasic) e
 			remoteAddr: s.conn.RawConn().RemoteAddr(),
 		}
 	}
-	for _, col := range columns {
-		col.Reset()
-	}
 	return nil
 }
 


### PR DESCRIPTION
As far as I understand, the fix is only to not reset buffers in Write. By the way, the documentation of Write says it is already the case.

The pull request is only on v3 as it is the version I'm using but I think the same bug exists in v2.