### PR TITLE
feat(format): file/dir/zero-copy ClickHouse Native I/O

### DIFF
--- a/chconn.go
+++ b/chconn.go
@@ -60,10 +60,10 @@ const (
 	// Columns' description for default values calculation
 	serverTableColumns = 11
 	// list of unique parts ids.
-	//nolint:deadcode,unused,varcheck
+	//nolint:unused
 	serverPartUUIDs = 12
 	// String (UUID) describes a request for which next task is needed
-	//nolint:deadcode,unused,varcheck
+	//nolint:unused
 	serverReadTaskRequest = 13
 	// System logs of query execution
 	serverLog = 10

--- a/chpool/pool.go
+++ b/chpool/pool.go
@@ -428,7 +428,7 @@ func ParseConfig(connString string) (*Config, error) {
 			return nil, fmt.Errorf("cannot parse pool_max_conns: %w", err)
 		}
 		if n < 1 {
-			//nolint:goerr113
+			//nolint:err113
 			return nil, fmt.Errorf("pool_max_conns too small: %d", n)
 		}
 		config.MaxConns = int32(n)

--- a/cmd/chgen/chgentest/integration_test.go
+++ b/cmd/chgen/chgentest/integration_test.go
@@ -62,7 +62,7 @@ func TestIntegration_InsertAndSelect(t *testing.T) {
 	err = conn.Exec(ctx, createTableSQL)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		conn.Exec(ctx, "DROP TABLE IF EXISTS test_chgen") //nolint:errcheck
+		conn.Exec(ctx, "DROP TABLE IF EXISTS test_chgen")
 	})
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -217,7 +217,7 @@ func TestIntegration_SelectMultipleBlocks(t *testing.T) {
 	err = conn.Exec(ctx, createBlocksTableSQL)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		conn.Exec(ctx, "DROP TABLE IF EXISTS test_chgen_blocks") //nolint:errcheck
+		conn.Exec(ctx, "DROP TABLE IF EXISTS test_chgen_blocks")
 	})
 
 	const rowCount = 1000

--- a/cmd/chgen/chgentest/model.go
+++ b/cmd/chgen/chgentest/model.go
@@ -14,8 +14,9 @@ const (
 	TestModelStatusInactive TestModelStatus = 2
 )
 
-//go:generate go tool chgen columns --input model.go
 // TestModel is a representative model with common ClickHouse column types.
+//
+//go:generate go tool chgen columns --input model.go
 type TestModel struct {
 	// Primitives
 	ID       uint64  `db:"id" chtype:"UInt64"`

--- a/cmd/chgen/colmap.go
+++ b/cmd/chgen/colmap.go
@@ -34,7 +34,7 @@ var fixedStringRe = regexp.MustCompile(`^\[(\d+)\]byte$`)
 
 // colMapping maps a Go field type + ClickHouse type tag to the correct
 // chconn column constructor info.
-func colMapping(goType string, chType string) (colInfo, error) {
+func colMapping(goType string, chType string) (colInfo, error) { //nolint:gocyclo,funlen,gocritic
 	goType = strings.TrimSpace(goType)
 	chType = strings.TrimSpace(chType)
 
@@ -225,11 +225,11 @@ func colMapping(goType string, chType string) (colInfo, error) {
 
 		keyInfo, err := colMapping(keyGoType, keyChType)
 		if err != nil {
-			return colInfo{}, fmt.Errorf("Map key: %w", err)
+			return colInfo{}, fmt.Errorf("map key: %w", err)
 		}
 		valInfo, err := colMapping(valGoType, valChType)
 		if err != nil {
-			return colInfo{}, fmt.Errorf("Map value: %w", err)
+			return colInfo{}, fmt.Errorf("map value: %w", err)
 		}
 		// Map(K, Nullable(V)): value is nullable → MapNullable
 		if valInfo.isNullable {
@@ -237,14 +237,14 @@ func colMapping(goType string, chType string) (colInfo, error) {
 			innerValGoType := valGoType[1:]
 			return colInfo{
 				fieldType:    fmt.Sprintf("*column.MapNullable[%s, %s]", keyGoType, innerValGoType),
-				constructor:  fmt.Sprintf("column.NewMapNullable[%s, %s](%s, %s)", keyGoType, innerValGoType, innerConstructor(keyInfo.constructor), innerConstructor(valInfo.constructor)),
+				constructor:  fmt.Sprintf("column.NewMapNullable[%s, %s](%s, %s)", keyGoType, innerValGoType, innerConstructor(keyInfo.constructor), innerConstructor(valInfo.constructor)), //nolint:lll
 				appendMethod: "AppendP",
 				rowMethod:    "RowP",
 			}, nil
 		}
 		return colInfo{
 			fieldType:    fmt.Sprintf("*column.Map[%s, %s]", keyGoType, valGoType),
-			constructor:  fmt.Sprintf("column.NewMap[%s, %s](%s, %s)", keyGoType, valGoType, innerConstructor(keyInfo.constructor), innerConstructor(valInfo.constructor)),
+			constructor:  fmt.Sprintf("column.NewMap[%s, %s](%s, %s)", keyGoType, valGoType, innerConstructor(keyInfo.constructor), innerConstructor(valInfo.constructor)), //nolint:lll
 			appendMethod: "Append",
 			rowMethod:    "Row",
 		}, nil
@@ -286,7 +286,7 @@ func colMapping(goType string, chType string) (colInfo, error) {
 	// Apply LowCardinality wrapper if needed.
 	if isLC {
 		ci.fieldType = fmt.Sprintf("*column.LowCardinality[%s]", goType)
-		ci.constructor = ci.constructor + ".LowCardinality()"
+		ci.constructor += ".LowCardinality()"
 	}
 
 	return ci, nil
@@ -300,7 +300,7 @@ func innerConstructor(c string) string {
 }
 
 // parseMapGoType parses "map[K]V" and returns K and V as strings.
-func parseMapGoType(goType string) (string, string, error) {
+func parseMapGoType(goType string) (string, string, error) { //nolint:gocritic
 	if !strings.HasPrefix(goType, "map[") {
 		return "", "", fmt.Errorf("not a map type")
 	}
@@ -324,7 +324,7 @@ func parseMapGoType(goType string) (string, string, error) {
 }
 
 // baseColMapping handles scalar types (no Nullable/Array/Map wrappers).
-func baseColMapping(goType string, chType string) (colInfo, error) {
+func baseColMapping(goType string, chType string) (colInfo, error) { //nolint:gocyclo,funlen,gocritic
 	// Special case: string
 	if goType == "string" {
 		if chType == "String" {
@@ -406,7 +406,7 @@ func baseColMapping(goType string, chType string) (colInfo, error) {
 	// Tuple/Nested: mapped to any — not directly constructible by chgen.
 	// Users must define the column manually.
 	if goType == "any" {
-		return colInfo{}, fmt.Errorf("Go type %q (from Tuple/Nested) requires manual column definition", goType)
+		return colInfo{}, fmt.Errorf("go type %q (from Tuple/Nested) requires manual column definition", goType)
 	}
 
 	// JSON type: json.RawMessage maps to *column.JSON
@@ -501,8 +501,8 @@ func baseColMapping(goType string, chType string) (colInfo, error) {
 }
 
 // chTypeToGoScalar returns the canonical Go type for a scalar ClickHouse type,
-// and a boolean indicating whether the chtype is recognised.
-func chTypeToGoScalar(chType string) (string, bool) {
+// and a boolean indicating whether the chtype is recognized.
+func chTypeToGoScalar(chType string) (string, bool) { //nolint:gocyclo
 	switch chType {
 	case "Int8":
 		return "int8", true

--- a/cmd/chgen/colmap_test.go
+++ b/cmd/chgen/colmap_test.go
@@ -11,22 +11,21 @@ import (
 // TestColMapping_Primitives covers uint64/UInt64, int32/Int32, float32/Float32, bool/UInt8, int8/Int8.
 func TestColMapping_Primitives(t *testing.T) {
 	cases := []struct {
-		goType      string
-		chType      string
-		wantField   string
-		wantCtor    string
+		goType    string
+		chType    string
+		wantField string
+		wantCtor  string
 	}{
 		{"uint64", "UInt64", "*column.Base[uint64]", "column.New[uint64]()"},
 		{"int32", "Int32", "*column.Base[int32]", "column.New[int32]()"},
 		{"float32", "Float32", "*column.Base[float32]", "column.New[float32]()"},
-		{"bool", "UInt8", "", ""},   // bool maps to Bool, not UInt8 — expect error
+		{"bool", "UInt8", "", ""}, // bool maps to Bool, not UInt8 — expect error
 		{"int8", "Int8", "*column.Base[int8]", "column.New[int8]()"},
 		{"uint8", "UInt8", "*column.Base[uint8]", "column.New[uint8]()"},
 		{"bool", "Bool", "*column.Base[bool]", "column.New[bool]()"},
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.goType+"/"+tc.chType, func(t *testing.T) {
 			info, err := colMapping(tc.goType, tc.chType)
 			if tc.wantField == "" {
@@ -269,7 +268,6 @@ func TestColMapping_Decimal(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.goType+"/"+tc.chType, func(t *testing.T) {
 			info, err := colMapping(tc.goType, tc.chType)
 			require.NoError(t, err)

--- a/cmd/chgen/columns.go
+++ b/cmd/chgen/columns.go
@@ -200,7 +200,7 @@ func resolveTupleSubColumns(pkg *packages.Package, fset *token.FileSet, parentFi
 
 	prefix := lowerFirst(parentFieldName)
 	var subs []tupleSubCol
-	for _, sf := range subFields {
+	for _, sf := range subFields { //nolint:gocritic
 		if _, ok := chArgs[sf.DBName]; !ok {
 			continue // sub-field not in the chtype definition
 		}
@@ -219,7 +219,7 @@ func resolveTupleSubColumns(pkg *packages.Package, fset *token.FileSet, parentFi
 }
 
 // generateColumns parses inputFile, finds tagged structs, and writes generated code to outFile.
-func generateColumns(inputFile, outFile string, withIter bool) error {
+func generateColumns(inputFile, outFile string, withIter bool) error { //nolint:gocyclo
 	absInput, err := filepath.Abs(inputFile)
 	if err != nil {
 		return fmt.Errorf("resolving input path: %w", err)
@@ -347,7 +347,7 @@ func generateColumns(inputFile, outFile string, withIter bool) error {
 		formatted = buf.Bytes()
 	}
 
-	if err := os.WriteFile(outFile, formatted, 0o644); err != nil {
+	if err := os.WriteFile(outFile, formatted, 0o644); err != nil { //nolint:gosec
 		return fmt.Errorf("writing output: %w", err)
 	}
 	return nil
@@ -355,23 +355,23 @@ func generateColumns(inputFile, outFile string, withIter bool) error {
 
 func columnNamesList(s structInfo) string {
 	var names []string
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		names = append(names, f.DBName)
 	}
 	return strings.Join(names, ", ")
 }
 
-func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
+func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) { //nolint:gocyclo,funlen
 	name := s.Name
 	colsName := name + "Columns"
 
 	// Struct definition
 	fmt.Fprintf(buf, "// %s holds the columns for reading/writing %s rows.\n", colsName, name)
 	fmt.Fprintf(buf, "type %s struct {\n", colsName)
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		if f.Col.isTuple || f.Col.isNested {
 			// Sub-column fields (unexported)
-			for _, sub := range f.Col.subColumns {
+			for _, sub := range f.Col.subColumns { //nolint:gocritic
 				fmt.Fprintf(buf, "\t%s %s\n", sub.colVarName, sub.col.fieldType)
 			}
 			// Exported Tuple/Nested field
@@ -384,7 +384,7 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 
 	// Check if any field is Tuple/Nested
 	hasTupleOrNested := false
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		if f.Col.isTuple || f.Col.isNested {
 			hasTupleOrNested = true
 			break
@@ -398,13 +398,13 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 	if hasTupleOrNested {
 		// Use assignment style when Tuple/Nested fields exist
 		fmt.Fprintf(buf, "\tt := &%s{}\n", colsName)
-		for _, f := range s.Fields {
+		for _, f := range s.Fields { //nolint:gocritic
 			if f.Col.isTuple {
-				for _, sub := range f.Col.subColumns {
+				for _, sub := range f.Col.subColumns { //nolint:gocritic
 					fmt.Fprintf(buf, "\tt.%s = %s\n", sub.colVarName, sub.col.constructor)
 				}
 				fmt.Fprintf(buf, "\tt.%s = column.NewTuple(", f.Name)
-				for i, sub := range f.Col.subColumns {
+				for i, sub := range f.Col.subColumns { //nolint:gocritic
 					if i > 0 {
 						buf.WriteString(", ")
 					}
@@ -412,11 +412,11 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 				}
 				buf.WriteString(")\n")
 			} else if f.Col.isNested {
-				for _, sub := range f.Col.subColumns {
+				for _, sub := range f.Col.subColumns { //nolint:gocritic
 					fmt.Fprintf(buf, "\tt.%s = %s\n", sub.colVarName, sub.col.constructor)
 				}
 				fmt.Fprintf(buf, "\tt.%s = column.NewNested(", f.Name)
-				for i, sub := range f.Col.subColumns {
+				for i, sub := range f.Col.subColumns { //nolint:gocritic
 					if i > 0 {
 						buf.WriteString(", ")
 					}
@@ -428,23 +428,23 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 			}
 		}
 		// SetName calls
-		for _, f := range s.Fields {
+		for _, f := range s.Fields { //nolint:gocritic
 			fmt.Fprintf(buf, "\tt.%s.SetName([]byte(%q))\n", f.Name, f.DBName)
 		}
 	} else {
 		// Use struct literal style (backward compatible)
 		fmt.Fprintf(buf, "\tt := &%s{\n", colsName)
-		for _, f := range s.Fields {
+		for _, f := range s.Fields { //nolint:gocritic
 			fmt.Fprintf(buf, "\t\t%s: %s,\n", f.Name, f.Col.constructor)
 		}
 		fmt.Fprintf(buf, "\t}\n")
 		// SetName calls
-		for _, f := range s.Fields {
+		for _, f := range s.Fields { //nolint:gocritic
 			fmt.Fprintf(buf, "\tt.%s.SetName([]byte(%q))\n", f.Name, f.DBName)
 		}
 	}
 	// SetStrict(false) calls
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		if f.Col.needsStrictFalse {
 			fmt.Fprintf(buf, "\tt.%s.SetStrict(false)\n", f.Name)
 		}
@@ -456,7 +456,7 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 	fmt.Fprintf(buf, "// Columns returns the list of ColumnCore for use with SelectStmt.\n")
 	fmt.Fprintf(buf, "func (t *%s) Columns() []column.ColumnCore {\n", colsName)
 	fmt.Fprintf(buf, "\treturn []column.ColumnCore{\n")
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		fmt.Fprintf(buf, "\t\tt.%s,\n", f.Name)
 	}
 	fmt.Fprintf(buf, "\t}\n")
@@ -465,17 +465,17 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 	// Write() method
 	fmt.Fprintf(buf, "// Write appends a single %s row to all columns.\n", name)
 	fmt.Fprintf(buf, "func (t *%s) Write(m *%s) {\n", colsName, name)
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		if f.Col.isTuple {
 			// Write sub-columns from struct fields
-			for _, sub := range f.Col.subColumns {
+			for _, sub := range f.Col.subColumns { //nolint:gocritic
 				fmt.Fprintf(buf, "\tt.%s.%s(m.%s.%s)\n", sub.colVarName, sub.col.appendMethod, f.Name, sub.fieldName)
 			}
 		} else if f.Col.isNested {
 			// Write nested: AppendLen + loop
 			fmt.Fprintf(buf, "\tt.%s.AppendLen(len(m.%s))\n", f.Name, f.Name)
 			fmt.Fprintf(buf, "\tfor _, v := range m.%s {\n", f.Name)
-			for _, sub := range f.Col.subColumns {
+			for _, sub := range f.Col.subColumns { //nolint:gocritic
 				fmt.Fprintf(buf, "\t\tt.%s.%s(v.%s)\n", sub.colVarName, sub.col.appendMethod, sub.fieldName)
 			}
 			fmt.Fprintf(buf, "\t}\n")
@@ -489,11 +489,11 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 	fmt.Fprintf(buf, "// Read reads a single row at index row from all columns.\n")
 	fmt.Fprintf(buf, "func (t *%s) Read(row int) %s {\n", colsName, name)
 	fmt.Fprintf(buf, "\treturn %s{\n", name)
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		if f.Col.isTuple {
 			// Reconstruct struct from sub-columns
 			fmt.Fprintf(buf, "\t\t%s: %s{\n", f.Name, f.Col.goType)
-			for _, sub := range f.Col.subColumns {
+			for _, sub := range f.Col.subColumns { //nolint:gocritic
 				fmt.Fprintf(buf, "\t\t\t%s: t.%s.%s(row),\n", sub.fieldName, sub.colVarName, sub.col.rowMethod)
 			}
 			fmt.Fprintf(buf, "\t\t},\n")
@@ -510,7 +510,7 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 	// SetWriteBufferSize() method — only call on Tuple/ArrayBase (delegates to sub-columns)
 	fmt.Fprintf(buf, "// SetWriteBufferSize sets the write buffer size on all columns.\n")
 	fmt.Fprintf(buf, "func (t *%s) SetWriteBufferSize(n int) {\n", colsName)
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		fmt.Fprintf(buf, "\tt.%s.SetWriteBufferSize(n)\n", f.Name)
 	}
 	fmt.Fprintf(buf, "}\n\n")
@@ -518,7 +518,7 @@ func writeColumnsStruct(buf *bytes.Buffer, s structInfo, withIter bool) {
 	// Reset() method — only call on Tuple/ArrayBase (delegates to sub-columns)
 	fmt.Fprintf(buf, "// Reset resets all columns to empty.\n")
 	fmt.Fprintf(buf, "func (t *%s) Reset() {\n", colsName)
-	for _, f := range s.Fields {
+	for _, f := range s.Fields { //nolint:gocritic
 		fmt.Fprintf(buf, "\tt.%s.Reset()\n", f.Name)
 	}
 	fmt.Fprintf(buf, "}\n\n")

--- a/cmd/chgen/model.go
+++ b/cmd/chgen/model.go
@@ -198,7 +198,7 @@ func splitCamel(s string) []string {
 }
 
 // generateModel generates the Go struct file from column definitions.
-func generateModel(cfg modelConfig, columns []columnSchema) error {
+func generateModel(cfg modelConfig, columns []columnSchema) error { //nolint:gocritic
 	// Determine package name
 	pkg := cfg.pkg
 	if pkg == "" {
@@ -311,7 +311,7 @@ func generateModel(cfg modelConfig, columns []columnSchema) error {
 	if err := os.MkdirAll(filepath.Dir(cfg.out), 0o755); err != nil {
 		return fmt.Errorf("creating output directory: %w", err)
 	}
-	if err := os.WriteFile(cfg.out, formatted, 0o644); err != nil {
+	if err := os.WriteFile(cfg.out, formatted, 0o644); err != nil { //nolint:gosec
 		return fmt.Errorf("writing output: %w", err)
 	}
 	return nil

--- a/cmd/chgen/testdata/all_types_model.go
+++ b/cmd/chgen/testdata/all_types_model.go
@@ -105,9 +105,9 @@ type AllTypes struct {
 	ColUint256 types.Uint256 `db:"col_uint256" chtype:"UInt256"`
 
 	// Geo types
-	ColPoint        types.Point      `db:"col_point" chtype:"Point"`
-	ColRing         []types.Point    `db:"col_ring" chtype:"Ring"`
-	ColPolygon      [][]types.Point  `db:"col_polygon" chtype:"Polygon"`
+	ColPoint        types.Point       `db:"col_point" chtype:"Point"`
+	ColRing         []types.Point     `db:"col_ring" chtype:"Ring"`
+	ColPolygon      [][]types.Point   `db:"col_polygon" chtype:"Polygon"`
 	ColMultiPolygon [][][]types.Point `db:"col_multi_polygon" chtype:"MultiPolygon"`
 
 	// Nullable DateTime

--- a/cmd/chgen/typemap.go
+++ b/cmd/chgen/typemap.go
@@ -20,7 +20,7 @@ var enumValueRe = regexp.MustCompile(`'([^']+)'\s*=\s*(-?\d+)`)
 // chTypeToGo converts a ClickHouse type string to Go type information.
 // If timeAsUint is true, date/time types are mapped to their underlying
 // integer type instead of time.Time.
-func chTypeToGo(chType string, timeAsUint bool) (goTypeInfo, error) {
+func chTypeToGo(chType string, timeAsUint bool) (goTypeInfo, error) { //nolint:gocyclo,funlen
 	chType = strings.TrimSpace(chType)
 
 	// --- Wrappers that delegate recursively ---
@@ -70,11 +70,11 @@ func chTypeToGo(chType string, timeAsUint bool) (goTypeInfo, error) {
 		valStr := strings.TrimSpace(args[comma+1:])
 		keyInfo, err := chTypeToGo(keyStr, timeAsUint)
 		if err != nil {
-			return goTypeInfo{}, fmt.Errorf("Map key: %w", err)
+			return goTypeInfo{}, fmt.Errorf("map key: %w", err)
 		}
 		valInfo, err := chTypeToGo(valStr, timeAsUint)
 		if err != nil {
-			return goTypeInfo{}, fmt.Errorf("Map value: %w", err)
+			return goTypeInfo{}, fmt.Errorf("map value: %w", err)
 		}
 		return goTypeInfo{goType: fmt.Sprintf("map[%s]%s", keyInfo.goType, valInfo.goType)}, nil
 	}
@@ -102,7 +102,7 @@ func chTypeToGo(chType string, timeAsUint bool) (goTypeInfo, error) {
 		case prec <= 76:
 			return goTypeInfo{goType: "types.Decimal256"}, nil
 		default:
-			return goTypeInfo{}, fmt.Errorf("Decimal precision %d exceeds max 76", prec)
+			return goTypeInfo{}, fmt.Errorf("decimal precision %d exceeds max 76", prec)
 		}
 	}
 

--- a/cmd/chgen/typemap_test.go
+++ b/cmd/chgen/typemap_test.go
@@ -68,7 +68,6 @@ func TestChTypeToGo_DateTime(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		name := tc.chType
 		if tc.timeAsUint {
 			name += "/timeAsUint"

--- a/column/base_big_cpu.go
+++ b/column/base_big_cpu.go
@@ -9,10 +9,10 @@ import (
 	"github.com/vahid-sohrabloo/chconn/v3/internal/helper"
 )
 
-// ReadAll read all value in this block and append to the input slice
 func (c *Base[T]) readBufferHook() {
-	for i := 0; i < c.totalByte; i += c.size {
-		reverseBuffer(c.b[i : i+c.size])
+	dst := helper.ConvertToByte(c.values, c.size)
+	for i := 0; i < len(dst); i += c.size {
+		reverseBuffer(dst[i : i+c.size])
 	}
 }
 

--- a/column/column_helper.go
+++ b/column/column_helper.go
@@ -210,9 +210,10 @@ func type2Column(rtype reflect.Type, arrayLevel int, nullable bool) (ColumnCore,
 	}
 }
 
-//nolint:funlen,gocyclo
 // ColumnByType creates a [ColumnCore] from a ClickHouse type string.
 // It handles all built-in types including Array, Nullable, LowCardinality, Map, Tuple, and Variant.
+//
+//nolint:funlen,gocyclo
 func ColumnByType(chType []byte, arrayLevel int, nullable, lc bool, serverTimeZone string) (ColumnCore, error) {
 	switch {
 	case string(chType) == "Bool":

--- a/column/map_base.go
+++ b/column/map_base.go
@@ -415,7 +415,7 @@ func (c *MapBase) SetColumnHeader(ch ColumnHeader) error {
 	}
 
 	if len(columnsMap) != 2 {
-		//nolint:goerr113
+		//nolint:err113
 		return fmt.Errorf("columns number is not equal to map columns number: %d != %d", len(columnsMap), 2)
 	}
 

--- a/column/shared_variant.go
+++ b/column/shared_variant.go
@@ -197,7 +197,7 @@ func (c *SharedVariant) ToJSON(row int, ignoreDoubleQuotes bool, b []byte) []byt
 	return b
 }
 
-//nolint:gocyclo,gocritic
+//nolint:gocyclo,gocritic,funlen
 func (c *SharedVariant) valueToJSON(btype binaryBaseType, data []byte, ignoreDoubleQuotes bool, b []byte) ([]byte, []byte) {
 	switch btype.bType {
 	case helper.BinaryTypeIndexNothing:

--- a/column/string_base.go
+++ b/column/string_base.go
@@ -587,6 +587,9 @@ func (c *StringBase[T]) writeBinaryDataTo(w *readerwriter.Writer) {
 // ReadFromBytes implements ZeroCopyColumn by aliasing data and indexing each
 // value's varint length prefix. The column becomes read-only; data must outlive it.
 func (c *StringBase[T]) ReadFromBytes(num int, data []byte) (int, error) {
+	if num < 0 {
+		return 0, fmt.Errorf("string column %q: ReadFromBytes: num must be >= 0, got %d", c.columnHeader.Name, num)
+	}
 	c.Reset()
 	off := 0
 	for i := range num {

--- a/column/string_base.go
+++ b/column/string_base.go
@@ -589,7 +589,7 @@ func (c *StringBase[T]) writeBinaryDataTo(w *readerwriter.Writer) {
 func (c *StringBase[T]) ReadFromBytes(num int, data []byte) (int, error) {
 	c.Reset()
 	off := 0
-	for i := 0; i < num; i++ {
+	for i := range num {
 		l, n := binary.Uvarint(data[off:])
 		if n <= 0 {
 			return 0, fmt.Errorf("string column %q: bad length varint at row %d", c.columnHeader.Name, i)

--- a/column/string_base.go
+++ b/column/string_base.go
@@ -583,3 +583,26 @@ func (c *StringBase[T]) ToJSON(row int, ignoreDoubleQuotes bool, b []byte) []byt
 func (c *StringBase[T]) writeBinaryDataTo(w *readerwriter.Writer) {
 	w.Uint8(uint8(helper.BinaryTypeIndexString))
 }
+
+// ReadFromBytes implements ZeroCopyColumn by aliasing data and indexing each
+// value's varint length prefix. The column becomes read-only; data must outlive it.
+func (c *StringBase[T]) ReadFromBytes(num int, data []byte) (int, error) {
+	c.Reset()
+	off := 0
+	for i := 0; i < num; i++ {
+		l, n := binary.Uvarint(data[off:])
+		if n <= 0 {
+			return 0, fmt.Errorf("string column %q: bad length varint at row %d", c.columnHeader.Name, i)
+		}
+		off += n
+		if l > uint64(len(data)-off) {
+			return 0, fmt.Errorf("string column %q: value length %d overflows buffer at row %d", c.columnHeader.Name, l, i)
+		}
+		end := off + int(l)
+		c.pos = append(c.pos, stringPos{start: off, end: end})
+		off = end
+	}
+	c.vals = data[:off:off] // cap==len so any later append reallocates (never writes into the alias)
+	c.numRow = num
+	return off, nil
+}

--- a/column/tuple.go
+++ b/column/tuple.go
@@ -262,7 +262,7 @@ func (c *Tuple) SetColumnHeader(ch ColumnHeader) error {
 		c.isEmpty = true
 	}
 	if len(columnsTuple) != len(c.columns) {
-		//nolint:goerr113
+		//nolint:err113
 		return fmt.Errorf("columns number for %s (%s) is not equal to tuple columns number: %d != %d",
 			string(c.columnHeader.Name),
 			string(c.Type()),

--- a/column/variant.go
+++ b/column/variant.go
@@ -259,7 +259,7 @@ func (c *Variant) SetColumnHeader(ch ColumnHeader) error {
 		return fmt.Errorf("Variant invalid types %w", err)
 	}
 	if len(columnsVariant) != len(c.columns) {
-		//nolint:goerr113
+		//nolint:err113
 		return fmt.Errorf("columns number for %s (%s) is not equal to Variant columns number: %d != %d",
 			string(c.columnHeader.Name),
 			string(c.Type()),

--- a/column/zerocopy.go
+++ b/column/zerocopy.go
@@ -1,0 +1,41 @@
+package column
+
+import "fmt"
+
+// ZeroCopyColumn is implemented by columns that can be populated for `num` rows
+// by aliasing an externally-owned byte buffer (e.g. an mmap) instead of copying
+// it onto the heap. On amd64/arm64 the column's data aliases `data` directly
+// (no allocation); on other CPUs it copies (and byte-swaps on big-endian).
+//
+// The buffer MUST outlive the column, and the column becomes READ-ONLY: any
+// mutating operation is unsupported on an aliased column — `SetAt`, `Append`
+// that grows beyond the aliased length, `Delete`, `DeleteFunc`, and batch-delete
+// all write in place and would corrupt or fault (SIGSEGV on a read-only mmap)
+// the backing buffer. Returns the number of bytes consumed from `data`.
+type ZeroCopyColumn interface {
+	ReadFromBytes(num int, data []byte) (consumed int, err error)
+}
+
+// ReadFromBytes implements ZeroCopyColumn for fixed-size columns.
+func (c *Base[T]) ReadFromBytes(num int, data []byte) (int, error) {
+	if num < 0 {
+		return 0, fmt.Errorf("column %q: ReadFromBytes: num must be >= 0, got %d", c.columnHeader.Name, num)
+	}
+	if c.size == 0 {
+		return 0, fmt.Errorf("column %q: ReadFromBytes: zero element size", c.columnHeader.Name)
+	}
+	if num > len(data)/c.size {
+		return 0, fmt.Errorf("column %q: ReadFromBytes needs %d rows * %d bytes, have %d", c.columnHeader.Name, num, c.size, len(data))
+	}
+	need := num * c.size
+	if len(data) < need {
+		return 0, fmt.Errorf("column %q: ReadFromBytes needs %d bytes, have %d",
+			c.columnHeader.Name, need, len(data))
+	}
+	c.Reset()
+	c.numRow = num
+	if num > 0 {
+		c.readFromBytesAlias(num, data[:need])
+	}
+	return need, nil
+}

--- a/column/zerocopy_alias_fast.go
+++ b/column/zerocopy_alias_fast.go
@@ -1,0 +1,10 @@
+//go:build amd64 || arm64
+
+package column
+
+import "unsafe"
+
+// readFromBytesAlias points values at data with no copy (fast, unaligned-safe arches).
+func (c *Base[T]) readFromBytesAlias(num int, data []byte) {
+	c.values = unsafe.Slice((*T)(unsafe.Pointer(&data[0])), num)
+}

--- a/column/zerocopy_alias_fast.go
+++ b/column/zerocopy_alias_fast.go
@@ -6,5 +6,9 @@ import "unsafe"
 
 // readFromBytesAlias points values at data with no copy (fast, unaligned-safe arches).
 func (c *Base[T]) readFromBytesAlias(num int, data []byte) {
+	if num == 0 {
+		c.values = nil
+		return
+	}
 	c.values = unsafe.Slice((*T)(unsafe.Pointer(&data[0])), num)
 }

--- a/column/zerocopy_alias_generic.go
+++ b/column/zerocopy_alias_generic.go
@@ -17,6 +17,10 @@ var zeroCopyLittleEndian = func() bool {
 // readFromBytesAlias copies into an aligned heap slice (avoiding unaligned loads
 // on non-amd64/arm64 arches) and byte-swaps per element on big-endian CPUs.
 func (c *Base[T]) readFromBytesAlias(num int, data []byte) {
+	if num == 0 {
+		c.values = nil
+		return
+	}
 	c.values = helper.ResetSlice(c.values, num, true)
 	dst := helper.ConvertToByte(c.values, c.size)
 	copy(dst, data)

--- a/column/zerocopy_alias_generic.go
+++ b/column/zerocopy_alias_generic.go
@@ -1,0 +1,30 @@
+//go:build !amd64 && !arm64
+
+package column
+
+import (
+	"unsafe"
+
+	"github.com/vahid-sohrabloo/chconn/v3/internal/helper"
+)
+
+// zeroCopyLittleEndian reports the CPU byte order once at init.
+var zeroCopyLittleEndian = func() bool {
+	var x uint16 = 1
+	return *(*byte)(unsafe.Pointer(&x)) == 1
+}()
+
+// readFromBytesAlias copies into an aligned heap slice (avoiding unaligned loads
+// on non-amd64/arm64 arches) and byte-swaps per element on big-endian CPUs.
+func (c *Base[T]) readFromBytesAlias(num int, data []byte) {
+	c.values = helper.ResetSlice(c.values, num, true)
+	dst := helper.ConvertToByte(c.values, c.size)
+	copy(dst, data)
+	if !zeroCopyLittleEndian && c.size > 1 {
+		for i := 0; i < len(dst); i += c.size {
+			for l, r := i, i+c.size-1; l < r; l, r = l+1, r-1 {
+				dst[l], dst[r] = dst[r], dst[l]
+			}
+		}
+	}
+}

--- a/column/zerocopy_test.go
+++ b/column/zerocopy_test.go
@@ -1,0 +1,118 @@
+package column
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+	"unsafe"
+)
+
+var _ ZeroCopyColumn = (*Base[float64])(nil)
+
+func TestBaseReadFromBytes_Float64(t *testing.T) {
+	src := []float64{1.5, -2.25, 0, 3.5e10}
+	buf := make([]byte, len(src)*8)
+	for i, v := range src {
+		binary.LittleEndian.PutUint64(buf[i*8:], math.Float64bits(v))
+	}
+
+	c := New[float64]()
+	consumed, err := c.ReadFromBytes(len(src), buf)
+	if err != nil {
+		t.Fatalf("ReadFromBytes: %v", err)
+	}
+	if consumed != len(buf) {
+		t.Fatalf("consumed = %d, want %d", consumed, len(buf))
+	}
+	if c.NumRow() != len(src) {
+		t.Fatalf("NumRow = %d, want %d", c.NumRow(), len(src))
+	}
+	for i, want := range src {
+		if got := c.Row(i); got != want {
+			t.Fatalf("Row(%d) = %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestBaseReadFromBytes_ShortBuffer(t *testing.T) {
+	c := New[int32]()
+	if _, err := c.ReadFromBytes(3, make([]byte, 8)); err == nil {
+		t.Fatal("expected error for short buffer, got nil")
+	}
+}
+
+// Asserts the little-endian path aliases (zero-copy) rather than copies.
+func TestBaseReadFromBytes_AliasesLE(t *testing.T) {
+	if !isLittleEndianForTest() {
+		t.Skip("alias check is little-endian only")
+	}
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, math.Float64bits(1.0))
+	c := New[float64]()
+	if _, err := c.ReadFromBytes(1, buf); err != nil {
+		t.Fatal(err)
+	}
+	binary.LittleEndian.PutUint64(buf, math.Float64bits(2.0)) // mutate backing buffer
+	if got := c.Row(0); got != 2.0 {
+		t.Fatalf("expected aliased view to reflect 2.0, got %v", got)
+	}
+}
+
+func TestBaseReadFromBytes_ZeroRows(t *testing.T) {
+	c := New[float64]()
+	consumed, err := c.ReadFromBytes(0, nil)
+	if err != nil || consumed != 0 || c.NumRow() != 0 {
+		t.Fatalf("zero-rows: consumed=%d err=%v numRow=%d", consumed, err, c.NumRow())
+	}
+}
+
+func isLittleEndianForTest() bool {
+	var x uint16 = 1
+	return *(*byte)(unsafePointerOf(&x)) == 1
+}
+
+func unsafePointerOf[T any](p *T) unsafe.Pointer { return unsafe.Pointer(p) }
+
+var _ ZeroCopyColumn = (*String)(nil)
+
+func TestStringReadFromBytes(t *testing.T) {
+	src := []string{"", "ab", "hello world", "x"}
+	var buf []byte
+	for _, s := range src {
+		buf = binary.AppendUvarint(buf, uint64(len(s)))
+		buf = append(buf, s...)
+	}
+
+	c := NewString()
+	consumed, err := c.ReadFromBytes(len(src), buf)
+	if err != nil {
+		t.Fatalf("ReadFromBytes: %v", err)
+	}
+	if consumed != len(buf) {
+		t.Fatalf("consumed = %d, want %d", consumed, len(buf))
+	}
+	if c.NumRow() != len(src) {
+		t.Fatalf("NumRow = %d, want %d", c.NumRow(), len(src))
+	}
+	for i, want := range src {
+		if got := c.Row(i); got != want {
+			t.Fatalf("Row(%d) = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestStringReadFromBytes_Truncated(t *testing.T) {
+	buf := binary.AppendUvarint(nil, 10) // claims 10 bytes, provides 2
+	buf = append(buf, "ab"...)
+	c := NewString()
+	if _, err := c.ReadFromBytes(1, buf); err == nil {
+		t.Fatal("expected truncation error, got nil")
+	}
+}
+
+func TestStringReadFromBytes_BadVarint(t *testing.T) {
+	c := NewString()
+	if _, err := c.ReadFromBytes(1, []byte{}); err == nil {
+		t.Fatal("expected bad-varint error on empty buffer, got nil")
+	}
+}

--- a/column/zerocopy_test.go
+++ b/column/zerocopy_test.go
@@ -116,3 +116,10 @@ func TestStringReadFromBytes_BadVarint(t *testing.T) {
 		t.Fatal("expected bad-varint error on empty buffer, got nil")
 	}
 }
+
+func TestStringReadFromBytes_NegativeCount(t *testing.T) {
+	c := NewString()
+	if _, err := c.ReadFromBytes(-1, []byte{}); err == nil {
+		t.Fatal("expected error for negative num, got nil")
+	}
+}

--- a/format/native.go
+++ b/format/native.go
@@ -10,6 +10,8 @@ import (
 	"github.com/vahid-sohrabloo/chconn/v3/shared"
 )
 
+const maxColumns = 1 << 20
+
 // NativeWriter writes columns in ClickHouse Native binary format to an io.Writer.
 type NativeWriter struct {
 	w            io.Writer
@@ -145,6 +147,10 @@ func (n *NativeReader) ReadBlock(r io.Reader, serverInfo *shared.ServerInfo) ([]
 		return nil, fmt.Errorf("native: read num columns: %w", err)
 	}
 
+	if numColumns > maxColumns {
+		return nil, fmt.Errorf("native: implausible column count %d", numColumns)
+	}
+
 	numRows, err := reader.Uvarint()
 	if err != nil {
 		return nil, fmt.Errorf("native: read num rows: %w", err)
@@ -202,6 +208,10 @@ func (n *NativeReader) ReadBlockInto(r io.Reader, serverInfo *shared.ServerInfo,
 	numColumns, err := reader.Uvarint()
 	if err != nil {
 		return fmt.Errorf("native: read num columns: %w", err)
+	}
+
+	if numColumns > maxColumns {
+		return fmt.Errorf("native: implausible column count %d", numColumns)
 	}
 
 	if int(numColumns) != len(columns) {

--- a/format/native_block_test.go
+++ b/format/native_block_test.go
@@ -1,0 +1,135 @@
+package format
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+func floatCol(name string, vals ...float64) *column.Base[float64] {
+	c := column.New[float64]()
+	c.SetName([]byte(name))
+	c.SetType([]byte("Float64"))
+	c.AppendMulti(vals...)
+	return c
+}
+
+func strCol(name string, vals ...string) *column.String {
+	c := column.NewString()
+	c.SetName([]byte(name))
+	c.SetType([]byte("String"))
+	for _, v := range vals {
+		c.Append(v)
+	}
+	return c
+}
+
+func TestBlockRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	nw := NewNativeWriter(&buf)
+	if err := nw.WriteBlock(
+		floatCol("cpm", 1.5, 2.5, 3.5),
+		strCol("bidder", "a", "bb", "ccc"),
+	); err != nil {
+		t.Fatalf("WriteBlock: %v", err)
+	}
+
+	nr := NewNativeReader()
+	cols, err := nr.ReadBlock(&buf, nil)
+	if err != nil {
+		t.Fatalf("ReadBlock: %v", err)
+	}
+	if len(cols) != 2 {
+		t.Fatalf("len(cols) = %d, want 2", len(cols))
+	}
+	if string(cols[0].Name()) != "cpm" || string(cols[1].Name()) != "bidder" {
+		t.Fatalf("names = %q,%q", cols[0].Name(), cols[1].Name())
+	}
+	gotF := cols[0].(*column.Base[float64])
+	if gotF.Row(0) != 1.5 || gotF.Row(2) != 3.5 {
+		t.Fatalf("float values wrong: %v %v", gotF.Row(0), gotF.Row(2))
+	}
+	gotS := cols[1].(*column.String)
+	if gotS.Row(1) != "bb" {
+		t.Fatalf("string value wrong: %q", gotS.Row(1))
+	}
+}
+
+func TestWriteBlockRequiresType(t *testing.T) {
+	c := column.New[float64]()
+	c.SetName([]byte("x"))
+	c.Append(1) // no SetType — WriteFile must reject this
+	if err := WriteFile(t.TempDir()+"/noType.native", []column.ColumnCore{c}); err == nil {
+		t.Fatal("expected error for missing type, got nil")
+	}
+}
+
+func TestWriteBlockRowMismatch(t *testing.T) {
+	nw := NewNativeWriter(io.Discard)
+	err := nw.WriteBlock(
+		floatCol("a", 1, 2),
+		floatCol("b", 1),
+	)
+	if err == nil {
+		t.Fatal("expected row-count mismatch error, got nil")
+	}
+}
+
+func TestReadBlockIntoCountMismatch(t *testing.T) {
+	var buf bytes.Buffer
+	nw := NewNativeWriter(&buf)
+	if err := nw.WriteBlock(floatCol("a", 1.0), floatCol("b", 2.0)); err != nil {
+		t.Fatal(err)
+	}
+	nr := NewNativeReader()
+	if err := nr.ReadBlockInto(&buf, nil, floatCol("a", 0)); err == nil {
+		t.Fatal("expected count mismatch error")
+	}
+}
+
+func TestReadBlockIntoIncompatibleColumn(t *testing.T) {
+	// Write one Float64 row (8 bytes data). A Nullable(UInt64) column needs
+	// null-bitmap (1 byte) + uint64 data (8 bytes) = 9 bytes — more than available,
+	// so ReadRaw must fail.
+	var buf bytes.Buffer
+	nw := NewNativeWriter(&buf)
+	if err := nw.WriteBlock(floatCol("x", 1.0)); err != nil {
+		t.Fatal(err)
+	}
+	nr := NewNativeReader()
+	dst := column.New[uint64]().Nullable()
+	dst.SetName([]byte("x"))
+	dst.SetType([]byte("Nullable(UInt64)"))
+	if err := nr.ReadBlockInto(&buf, nil, dst); err == nil {
+		t.Fatal("expected error reading structurally incompatible column data")
+	}
+}
+
+func TestReadBlockEOFAtBoundary(t *testing.T) {
+	var buf bytes.Buffer
+	nw := NewNativeWriter(&buf)
+	if err := nw.WriteBlock(floatCol("v", 1.0)); err != nil {
+		t.Fatal(err)
+	}
+	nr := NewNativeReader()
+	if _, err := nr.ReadBlock(&buf, nil); err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if _, err := nr.ReadBlock(&buf, nil); !errors.Is(err, io.EOF) {
+		t.Fatalf("second read: want io.EOF, got %v", err)
+	}
+}
+
+func TestNativeReaderHugeColumnCount(t *testing.T) {
+	var b []byte
+	b = binary.AppendUvarint(b, uint64(1)<<40) // absurd num_columns
+	b = binary.AppendUvarint(b, 0)             // num_rows
+	nr := NewNativeReader()
+	if _, err := nr.ReadBlock(bytes.NewReader(b), nil); err == nil {
+		t.Fatal("expected error for implausible column count")
+	}
+}

--- a/format/native_bytes.go
+++ b/format/native_bytes.go
@@ -42,7 +42,7 @@ func (br *BytesReader) ReadBlock() (int, []column.ColumnCore, error) {
 	}
 
 	cols := make([]column.ColumnCore, 0, numCols)
-	for i := uint64(0); i < numCols; i++ {
+	for range numCols {
 		name, err := br.bstring()
 		if err != nil {
 			return 0, nil, err

--- a/format/native_bytes.go
+++ b/format/native_bytes.go
@@ -1,0 +1,99 @@
+package format
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+// BytesReader reads Native-format blocks directly from an in-memory buffer
+// (typically an mmap the caller owns), aliasing column data with zero copies.
+// The zero-copy path assumes each column has an empty serialization header,
+// which is true for Base[T] and String columns. It is therefore suitable only
+// for those types; columns whose HeaderWriter emits bytes are not supported —
+// use OpenFile for such blocks. Returned columns and the strings they yield are
+// valid only while the backing buffer is alive and unmodified.
+type BytesReader struct {
+	data []byte
+	off  int
+}
+
+// OpenBytes wraps data for zero-copy reads. The caller owns data's lifetime.
+func OpenBytes(data []byte) *BytesReader { return &BytesReader{data: data} }
+
+// ReadBlock reads the next block, aliasing each column into the buffer.
+// Returns io.EOF when the buffer is exhausted.
+func (br *BytesReader) ReadBlock() (int, []column.ColumnCore, error) {
+	if br.off >= len(br.data) {
+		return 0, nil, io.EOF
+	}
+	numCols, err := br.uvarint()
+	if err != nil {
+		return 0, nil, err
+	}
+	if numCols > maxColumns {
+		return 0, nil, fmt.Errorf("native: implausible column count %d", numCols)
+	}
+	numRows, err := br.uvarint()
+	if err != nil {
+		return 0, nil, fmt.Errorf("native: read num_rows: %w", err)
+	}
+
+	cols := make([]column.ColumnCore, 0, numCols)
+	for i := uint64(0); i < numCols; i++ {
+		name, err := br.bstring()
+		if err != nil {
+			return 0, nil, err
+		}
+		chType, err := br.bstring()
+		if err != nil {
+			return 0, nil, err
+		}
+		chTypeCopy := append([]byte(nil), chType...)
+		col, err := column.ColumnByType(chTypeCopy, 0, false, false, "")
+		if err != nil {
+			return 0, nil, fmt.Errorf("native: column %q: %w", name, err)
+		}
+		zc, ok := col.(column.ZeroCopyColumn)
+		if !ok {
+			return 0, nil, fmt.Errorf("native: column %q (%s) does not support zero-copy reads; use OpenFile",
+				name, chType)
+		}
+		col.SetName(append([]byte(nil), name...))
+		consumed, err := zc.ReadFromBytes(int(numRows), br.data[br.off:])
+		if err != nil {
+			return 0, nil, fmt.Errorf("native: zero-copy read %q: %w", name, err)
+		}
+		br.off += consumed
+		cols = append(cols, col)
+	}
+	return int(numRows), cols, nil
+}
+
+func (br *BytesReader) uvarint() (uint64, error) {
+	v, n := binary.Uvarint(br.data[br.off:])
+	if n <= 0 {
+		return 0, fmt.Errorf("native: bad varint at offset %d", br.off)
+	}
+	br.off += n
+	return v, nil
+}
+
+func (br *BytesReader) bstring() ([]byte, error) {
+	l, err := br.uvarint()
+	if err != nil {
+		return nil, err
+	}
+	if l > uint64(len(br.data)-br.off) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	end := br.off + int(l)
+	if end > len(br.data) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	s := br.data[br.off:end]
+	br.off = end
+	return s, nil
+}

--- a/format/native_bytes.go
+++ b/format/native_bytes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/vahid-sohrabloo/chconn/v3/column"
 )
@@ -62,6 +63,9 @@ func (br *BytesReader) ReadBlock() (int, []column.ColumnCore, error) {
 				name, chType)
 		}
 		col.SetName(append([]byte(nil), name...))
+		if numRows > uint64(math.MaxInt) {
+			return 0, nil, fmt.Errorf("native: row count %d exceeds int range", numRows)
+		}
 		consumed, err := zc.ReadFromBytes(int(numRows), br.data[br.off:])
 		if err != nil {
 			return 0, nil, fmt.Errorf("native: zero-copy read %q: %w", name, err)

--- a/format/native_bytes_test.go
+++ b/format/native_bytes_test.go
@@ -1,0 +1,135 @@
+package format
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+	"unsafe"
+
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+func TestBytesReaderZeroCopy(t *testing.T) {
+	var buf bytes.Buffer
+	nw := NewNativeWriter(&buf)
+	if err := nw.WriteBlock(
+		floatCol("cpm", 1.5, 2.5, 3.5),
+		strCol("bidder", "a", "bb", "ccc"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	br := OpenBytes(buf.Bytes())
+	numRows, cols, err := br.ReadBlock()
+	if err != nil {
+		t.Fatalf("ReadBlock: %v", err)
+	}
+	if numRows != 3 || len(cols) != 2 {
+		t.Fatalf("got numRows=%d cols=%d", numRows, len(cols))
+	}
+	if cols[0].(*column.Base[float64]).Row(2) != 3.5 {
+		t.Fatal("wrong float value")
+	}
+	if cols[1].(*column.String).Row(2) != "ccc" {
+		t.Fatal("wrong string value")
+	}
+}
+
+// A column type without zero-copy support must produce a clear error.
+func TestBytesReaderRejectsNonZeroCopy(t *testing.T) {
+	c := column.New[uint64]().Nullable()
+	c.SetName([]byte("n"))
+	c.SetType([]byte("Nullable(UInt64)"))
+	c.AppendP(nil)
+	var buf bytes.Buffer
+	nw := NewNativeWriter(&buf)
+	if err := nw.WriteBlock(c); err != nil {
+		t.Fatal(err)
+	}
+	br := OpenBytes(buf.Bytes())
+	if _, _, err := br.ReadBlock(); err == nil {
+		t.Fatal("expected error for non-zero-copy column, got nil")
+	}
+}
+
+func TestBytesReaderFloat64Aliases(t *testing.T) {
+	var one uint16 = 1
+	if *(*byte)(unsafe.Pointer(&one)) != 1 {
+		t.Skip("alias is little-endian only")
+	}
+	var buf bytes.Buffer
+	nw := NewNativeWriter(&buf)
+	if err := nw.WriteBlock(floatCol("v", 1.0)); err != nil {
+		t.Fatal(err)
+	}
+	data := buf.Bytes()
+	_, cols, err := OpenBytes(data).ReadBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fc := cols[0].(*column.Base[float64])
+	if fc.Row(0) != 1.0 {
+		t.Fatalf("before mutate: got %v", fc.Row(0))
+	}
+	// Single float64 column: its 8-byte payload is the final 8 bytes of the file.
+	binary.LittleEndian.PutUint64(data[len(data)-8:], math.Float64bits(2.0))
+	if fc.Row(0) != 2.0 {
+		t.Fatalf("alias not reflected: got %v, want 2.0", fc.Row(0))
+	}
+}
+
+func TestBytesReaderHugeRowCountErrors(t *testing.T) {
+	var b []byte
+	b = binary.AppendUvarint(b, 1)             // num_columns
+	b = binary.AppendUvarint(b, uint64(1)<<62) // num_rows (absurd)
+	b = binary.AppendUvarint(b, uint64(len("v")))
+	b = append(b, "v"...)
+	b = binary.AppendUvarint(b, uint64(len("Float64")))
+	b = append(b, "Float64"...)
+	// no column data
+	_, _, err := OpenBytes(b).ReadBlock()
+	if err == nil {
+		t.Fatal("expected error for absurd row count, got nil (possible OOB)")
+	}
+}
+
+func TestBytesReaderHugeColCountErrors(t *testing.T) {
+	var b []byte
+	b = binary.AppendUvarint(b, uint64(1)<<40) // num_columns absurd
+	b = binary.AppendUvarint(b, 0)
+	if _, _, err := OpenBytes(b).ReadBlock(); err == nil {
+		t.Fatal("expected error for absurd column count")
+	}
+}
+
+func BenchmarkBytesReaderFloatScan(b *testing.B) {
+	var buf bytes.Buffer
+	vals := make([]float64, 100000)
+	for i := range vals {
+		vals[i] = float64(i)
+	}
+	c := column.New[float64]()
+	c.SetName([]byte("v"))
+	c.SetType([]byte("Float64"))
+	c.AppendMulti(vals...)
+	nw := NewNativeWriter(&buf)
+	if err := nw.WriteBlock(c); err != nil {
+		b.Fatal(err)
+	}
+	data := buf.Bytes()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, cols, err := OpenBytes(data).ReadBlock()
+		if err != nil {
+			b.Fatal(err)
+		}
+		var sum float64
+		for _, v := range cols[0].(*column.Base[float64]).Data() {
+			sum += v
+		}
+		_ = sum
+	}
+}

--- a/format/native_bytes_test.go
+++ b/format/native_bytes_test.go
@@ -94,6 +94,22 @@ func TestBytesReaderHugeRowCountErrors(t *testing.T) {
 	}
 }
 
+func TestBytesReaderRowCountExceedsIntRange(t *testing.T) {
+	// uint64(math.MaxInt)+1 cannot fit in int on any platform; the guard must fire.
+	numRows := uint64(math.MaxInt) + 1
+	var b []byte
+	b = binary.AppendUvarint(b, 1)       // num_columns
+	b = binary.AppendUvarint(b, numRows) // num_rows exceeds int range
+	b = binary.AppendUvarint(b, uint64(len("v")))
+	b = append(b, "v"...)
+	b = binary.AppendUvarint(b, uint64(len("Float64")))
+	b = append(b, "Float64"...)
+	_, _, err := OpenBytes(b).ReadBlock()
+	if err == nil {
+		t.Fatal("expected error for row count exceeding int range, got nil")
+	}
+}
+
 func TestBytesReaderHugeColCountErrors(t *testing.T) {
 	var b []byte
 	b = binary.AppendUvarint(b, uint64(1)<<40) // num_columns absurd

--- a/format/native_codec.go
+++ b/format/native_codec.go
@@ -1,0 +1,175 @@
+package format
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	kpzstd "github.com/klauspost/compress/zstd"
+	lz4 "github.com/pierrec/lz4/v4"
+)
+
+// maxCompressedUnit is a sanity bound for one compressed unit length (8 GiB).
+// Streams with a declared length exceeding this are rejected as corrupt or crafted.
+const maxCompressedUnit = 1 << 33
+
+// Codec is a pluggable one-shot compression codec. Compress appends the
+// compressed form of src to dst; Decompress appends the decompressed form to dst
+// (callers pass a dst pre-sized to the recorded uncompressed length). Both MUST
+// be safe for concurrent use if the codec is used with parallel dir-mode writes.
+type Codec struct {
+	Name       string
+	Compress   func(dst, src []byte) ([]byte, error)
+	Decompress func(dst, src []byte) ([]byte, error)
+}
+
+// shared klauspost encoder/decoder; EncodeAll/DecodeAll are concurrency-safe.
+var kpEnc, _ = kpzstd.NewWriter(nil, kpzstd.WithEncoderConcurrency(1))
+var kpDec, _ = kpzstd.NewReader(nil, kpzstd.WithDecoderConcurrency(1))
+
+func zstdCodec() *Codec {
+	return &Codec{
+		Name:       "zstd",
+		Compress:   func(dst, src []byte) ([]byte, error) { return kpEnc.EncodeAll(src, dst), nil },
+		Decompress: func(dst, src []byte) ([]byte, error) { return kpDec.DecodeAll(src, dst) },
+	}
+}
+
+func lz4Codec() *Codec {
+	return &Codec{
+		Name: "lz4",
+		Compress: func(dst, src []byte) ([]byte, error) {
+			var buf bytes.Buffer
+			w := lz4.NewWriter(&buf)
+			if _, err := w.Write(src); err != nil {
+				return nil, err
+			}
+			if err := w.Close(); err != nil {
+				return nil, err
+			}
+			return append(dst, buf.Bytes()...), nil
+		},
+		Decompress: func(dst, src []byte) ([]byte, error) {
+			r := lz4.NewReader(bytes.NewReader(src))
+			var buf bytes.Buffer
+			if _, err := io.Copy(&buf, r); err != nil {
+				return nil, err
+			}
+			return append(dst, buf.Bytes()...), nil
+		},
+	}
+}
+
+// compressedMagic prefixes every compressed native file so an uncompressed
+// reader fails fast and a codec-name mismatch can be detected.
+var compressedMagic = [4]byte{'C', 'N', 'C', '1'}
+
+// writeCompressedHeader writes the magic bytes followed by the codec name as a
+// uvarint-length-prefixed string.
+func writeCompressedHeader(w io.Writer, name string) error {
+	if _, err := w.Write(compressedMagic[:]); err != nil {
+		return err
+	}
+	hdr := binary.AppendUvarint(nil, uint64(len(name)))
+	hdr = append(hdr, name...)
+	_, err := w.Write(hdr)
+	return err
+}
+
+// readCompressedHeader verifies the magic bytes and that the stored codec name
+// matches wantName.
+func readCompressedHeader(r io.Reader, wantName string) error {
+	var magic [4]byte
+	if _, err := io.ReadFull(r, magic[:]); err != nil {
+		return fmt.Errorf("native: read compressed magic: %w", err)
+	}
+	if magic != compressedMagic {
+		return fmt.Errorf("native: not a chconn compressed native file (bad magic %v)", magic)
+	}
+	nameLen, err := readUvarint(r)
+	if err != nil {
+		return fmt.Errorf("native: read codec name length: %w", err)
+	}
+	name := make([]byte, nameLen)
+	if _, err := io.ReadFull(r, name); err != nil {
+		return fmt.Errorf("native: read codec name: %w", err)
+	}
+	if string(name) != wantName {
+		return fmt.Errorf("native: codec mismatch: file written with %q, reader configured with %q", string(name), wantName)
+	}
+	return nil
+}
+
+// writeCompressedUnit compresses plaintext and writes a unit:
+// uvarint(compLen), uvarint(uncompLen), then compLen compressed bytes.
+func writeCompressedUnit(w io.Writer, codec *Codec, plaintext []byte) error {
+	comp, err := codec.Compress(nil, plaintext)
+	if err != nil {
+		return fmt.Errorf("native: compress: %w", err)
+	}
+	hdr := binary.AppendUvarint(nil, uint64(len(comp)))
+	hdr = binary.AppendUvarint(hdr, uint64(len(plaintext)))
+	if _, err := w.Write(hdr); err != nil {
+		return err
+	}
+	if _, err := w.Write(comp); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readCompressedUnit reads one compressed unit and returns its decompressed
+// plaintext. The error from reading the first length is returned raw so io.EOF
+// propagates to signal end-of-stream.
+func readCompressedUnit(r io.Reader, codec *Codec) ([]byte, error) {
+	compLen, err := readUvarint(r)
+	if err != nil {
+		return nil, err
+	}
+	uncompLen, err := readUvarint(r)
+	if err != nil {
+		return nil, fmt.Errorf("native: read uncompressed length: %w", err)
+	}
+	if compLen > maxCompressedUnit || uncompLen > maxCompressedUnit {
+		return nil, fmt.Errorf("native: compressed unit length out of range (comp=%d uncomp=%d)", compLen, uncompLen)
+	}
+	comp := make([]byte, compLen)
+	if _, err := io.ReadFull(r, comp); err != nil {
+		return nil, fmt.Errorf("native: read compressed unit: %w", err)
+	}
+	plain, err := codec.Decompress(make([]byte, 0, uncompLen), comp)
+	if err != nil {
+		return nil, fmt.Errorf("native: decompress: %w", err)
+	}
+	if uint64(len(plain)) != uncompLen {
+		return nil, fmt.Errorf("native: decompressed length %d, expected %d", len(plain), uncompLen)
+	}
+	return plain, nil
+}
+
+// readUvarint reads a base-128 varint one byte at a time so a clean io.EOF on
+// the first byte propagates to the caller (used to detect end-of-stream).
+func readUvarint(r io.Reader) (uint64, error) {
+	var x uint64
+	var s uint
+	var buf [1]byte
+	for i := 0; ; i++ {
+		if _, err := io.ReadFull(r, buf[:]); err != nil {
+			if i > 0 && errors.Is(err, io.EOF) {
+				return x, io.ErrUnexpectedEOF
+			}
+			return x, err
+		}
+		b := buf[0]
+		if b < 0x80 {
+			if i > 9 || (i == 9 && b > 1) {
+				return x, fmt.Errorf("native: uvarint overflows uint64")
+			}
+			return x | uint64(b)<<s, nil
+		}
+		x |= uint64(b&0x7f) << s
+		s += 7
+	}
+}

--- a/format/native_codec.go
+++ b/format/native_codec.go
@@ -53,9 +53,14 @@ func lz4Codec() *Codec {
 		},
 		Decompress: func(dst, src []byte) ([]byte, error) {
 			r := lz4.NewReader(bytes.NewReader(src))
+			limit := int64(cap(dst))
 			var buf bytes.Buffer
-			if _, err := io.Copy(&buf, r); err != nil {
+			n, err := io.Copy(&buf, io.LimitReader(r, limit+1))
+			if err != nil {
 				return nil, err
+			}
+			if n > limit {
+				return nil, fmt.Errorf("native: lz4 decompressed size exceeds declared %d bytes", limit)
 			}
 			return append(dst, buf.Bytes()...), nil
 		},
@@ -91,6 +96,9 @@ func readCompressedHeader(r io.Reader, wantName string) error {
 	nameLen, err := readUvarint(r)
 	if err != nil {
 		return fmt.Errorf("native: read codec name length: %w", err)
+	}
+	if nameLen > 255 {
+		return fmt.Errorf("native: codec name length %d exceeds 255", nameLen)
 	}
 	name := make([]byte, nameLen)
 	if _, err := io.ReadFull(r, name); err != nil {
@@ -168,6 +176,9 @@ func readUvarint(r io.Reader) (uint64, error) {
 				return x, fmt.Errorf("native: uvarint overflows uint64")
 			}
 			return x | uint64(b)<<s, nil
+		}
+		if i >= 9 {
+			return x, fmt.Errorf("native: uvarint overflows uint64")
 		}
 		x |= uint64(b&0x7f) << s
 		s += 7

--- a/format/native_compress_test.go
+++ b/format/native_compress_test.go
@@ -1,22 +1,27 @@
 package format
 
 import (
+	"errors"
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
+	kpzstd "github.com/klauspost/compress/zstd"
 	"github.com/vahid-sohrabloo/chconn/v3/column"
 )
 
-func TestFileCompressedRoundTrip(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "data.native.lz4")
+func fileRoundTrip(t *testing.T, opts ...Option) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "data.native.z")
 	cols := []column.ColumnCore{
 		floatCol("cpm", 1.5, 2.5, 3.5),
 		strCol("bidder", "a", "bb", "ccc"),
 	}
-	if err := WriteFile(path, cols, WithLZ4()); err != nil {
+	if err := WriteFile(path, cols, opts...); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	fr, err := OpenFile(path, WithLZ4())
+	fr, err := OpenFile(path, opts...)
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}
@@ -28,30 +33,34 @@ func TestFileCompressedRoundTrip(t *testing.T) {
 	if n != 3 {
 		t.Fatalf("ReadBlock: got %d rows, want 3", n)
 	}
+	if got[0].(*column.Base[float64]).Row(2) != 3.5 {
+		t.Fatalf("cpm[2] = %v, want 3.5", got[0].(*column.Base[float64]).Row(2))
+	}
 	if got[1].(*column.String).Row(0) != "a" {
 		t.Fatalf("bidder[0] = %q, want %q", got[1].(*column.String).Row(0), "a")
 	}
 
-	// Prove the file is actually lz4-compressed: reading it without WithLZ4 must fail.
+	// Prove the file is actually compressed: reading it without the codec must fail.
 	plain, err := OpenFile(path)
 	if err != nil {
-		t.Fatalf("OpenFile (no lz4): %v", err)
+		t.Fatalf("OpenFile (no codec): %v", err)
 	}
 	defer plain.Close()
 	if _, _, err := plain.ReadBlock(); err == nil {
-		t.Fatal("expected error reading lz4 file without WithLZ4; compression may be a no-op")
+		t.Fatal("expected error reading compressed file without codec; compression may be a no-op")
 	}
 }
 
-func TestDirCompressedRoundTrip(t *testing.T) {
+func dirRoundTrip(t *testing.T, opts ...Option) {
+	t.Helper()
 	dir := t.TempDir()
 	if err := WriteDir(dir, []column.ColumnCore{
 		floatCol("cpm", 1.5, 2.5, 3.5),
 		strCol("bidder", "a", "bb", "ccc"),
-	}, WithLZ4()); err != nil {
+	}, opts...); err != nil {
 		t.Fatalf("WriteDir: %v", err)
 	}
-	dr, err := OpenDir(dir, WithLZ4())
+	dr, err := OpenDir(dir, opts...)
 	if err != nil {
 		t.Fatalf("OpenDir: %v", err)
 	}
@@ -65,5 +74,97 @@ func TestDirCompressedRoundTrip(t *testing.T) {
 	}
 	if col.(*column.Base[float64]).Row(0) != 1.5 {
 		t.Fatal("compressed dir round-trip mismatch")
+	}
+	bidder, err := dr.OpenColumn("bidder")
+	if err != nil {
+		t.Fatalf("OpenColumn bidder: %v", err)
+	}
+	if bidder.(*column.String).Row(2) != "ccc" {
+		t.Fatal("compressed dir round-trip string mismatch")
+	}
+}
+
+func TestFileZSTDRoundTrip(t *testing.T) { fileRoundTrip(t, WithZSTD()) }
+func TestDirZSTDRoundTrip(t *testing.T)  { dirRoundTrip(t, WithZSTD()) }
+
+func TestFileLZ4RoundTrip(t *testing.T) { fileRoundTrip(t, WithLZ4()) }
+func TestDirLZ4RoundTrip(t *testing.T)  { dirRoundTrip(t, WithLZ4()) }
+
+// customCodec wraps klauspost zstd under a distinct name to exercise WithCodec.
+func customCodec() Codec {
+	enc, _ := kpzstd.NewWriter(nil, kpzstd.WithEncoderConcurrency(1))
+	dec, _ := kpzstd.NewReader(nil, kpzstd.WithDecoderConcurrency(1))
+	return Codec{
+		Name:       "custom-x",
+		Compress:   func(dst, src []byte) ([]byte, error) { return enc.EncodeAll(src, dst), nil },
+		Decompress: func(dst, src []byte) ([]byte, error) { return dec.DecodeAll(src, dst) },
+	}
+}
+
+func TestFileCustomCodecRoundTrip(t *testing.T) { fileRoundTrip(t, WithCodec(customCodec())) }
+func TestDirCustomCodecRoundTrip(t *testing.T)  { dirRoundTrip(t, WithCodec(customCodec())) }
+
+func TestFileWriterMultiBlockCompressed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "multi.native.zst")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fw := NewFileWriter(f, WithZSTD())
+	if err := fw.WriteBlock(floatCol("v", 1, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := fw.WriteBlock(floatCol("v", 3, 4, 5)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	fr, err := OpenFile(path, WithZSTD())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fr.Close()
+	total := 0
+	for {
+		n, _, err := fr.ReadBlock()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				t.Fatalf("unexpected error reading block: %v", err)
+			}
+			break
+		}
+		total += n
+	}
+	if total != 5 {
+		t.Fatalf("total rows = %d, want 5", total)
+	}
+}
+
+func TestCodecNameMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.native.z")
+	cols := []column.ColumnCore{floatCol("cpm", 1.5, 2.5, 3.5)}
+	if err := WriteFile(path, cols, WithZSTD()); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	fr, err := OpenFile(path, WithLZ4())
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer fr.Close()
+	if _, _, err := fr.ReadBlock(); err == nil {
+		t.Fatal("expected codec mismatch error reading zstd file with WithLZ4")
+	}
+}
+
+func TestDirCompressedRequiresCodec(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{floatCol("v", 1, 2, 3)}, WithZSTD()); err != nil {
+		t.Fatal(err)
+	}
+	// OpenDir reads each file's header; without the codec it must fail, not silently succeed.
+	if _, err := OpenDir(dir); err == nil {
+		t.Fatal("expected OpenDir without codec to fail on compressed dir")
 	}
 }

--- a/format/native_compress_test.go
+++ b/format/native_compress_test.go
@@ -1,0 +1,69 @@
+package format
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+func TestFileCompressedRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.native.lz4")
+	cols := []column.ColumnCore{
+		floatCol("cpm", 1.5, 2.5, 3.5),
+		strCol("bidder", "a", "bb", "ccc"),
+	}
+	if err := WriteFile(path, cols, WithLZ4()); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	fr, err := OpenFile(path, WithLZ4())
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer fr.Close()
+	n, got, err := fr.ReadBlock()
+	if err != nil {
+		t.Fatalf("ReadBlock: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("ReadBlock: got %d rows, want 3", n)
+	}
+	if got[1].(*column.String).Row(0) != "a" {
+		t.Fatalf("bidder[0] = %q, want %q", got[1].(*column.String).Row(0), "a")
+	}
+
+	// Prove the file is actually lz4-compressed: reading it without WithLZ4 must fail.
+	plain, err := OpenFile(path)
+	if err != nil {
+		t.Fatalf("OpenFile (no lz4): %v", err)
+	}
+	defer plain.Close()
+	if _, _, err := plain.ReadBlock(); err == nil {
+		t.Fatal("expected error reading lz4 file without WithLZ4; compression may be a no-op")
+	}
+}
+
+func TestDirCompressedRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{
+		floatCol("cpm", 1.5, 2.5, 3.5),
+		strCol("bidder", "a", "bb", "ccc"),
+	}, WithLZ4()); err != nil {
+		t.Fatalf("WriteDir: %v", err)
+	}
+	dr, err := OpenDir(dir, WithLZ4())
+	if err != nil {
+		t.Fatalf("OpenDir: %v", err)
+	}
+	defer dr.Close()
+	if dr.RowCount() != 3 {
+		t.Fatalf("RowCount = %d, want 3", dr.RowCount())
+	}
+	col, err := dr.OpenColumn("cpm")
+	if err != nil {
+		t.Fatalf("OpenColumn: %v", err)
+	}
+	if col.(*column.Base[float64]).Row(0) != 1.5 {
+		t.Fatal("compressed dir round-trip mismatch")
+	}
+}

--- a/format/native_compress_test.go
+++ b/format/native_compress_test.go
@@ -163,8 +163,18 @@ func TestDirCompressedRequiresCodec(t *testing.T) {
 	if err := WriteDir(dir, []column.ColumnCore{floatCol("v", 1, 2, 3)}, WithZSTD()); err != nil {
 		t.Fatal(err)
 	}
-	// OpenDir reads each file's header; without the codec it must fail, not silently succeed.
-	if _, err := OpenDir(dir); err == nil {
-		t.Fatal("expected OpenDir without codec to fail on compressed dir")
+	// OpenDir reads the uncompressed sidecar only, so it succeeds without a codec.
+	dr, err := OpenDir(dir)
+	if err != nil {
+		t.Fatalf("OpenDir without codec should succeed (reads uncompressed sidecar): %v", err)
+	}
+	defer dr.Close()
+	// OpenColumn without codec must fail because the column data file is compressed.
+	if _, err := dr.OpenColumn("v"); err == nil {
+		t.Fatal("expected OpenColumn without codec to fail on compressed column data")
+	}
+	// OpenColumn with the correct codec must succeed.
+	if _, err := dr.OpenColumn("v", WithZSTD()); err != nil {
+		t.Fatalf("OpenColumn with codec: %v", err)
 	}
 }

--- a/format/native_dir.go
+++ b/format/native_dir.go
@@ -113,6 +113,9 @@ func readDirMeta(dir string) (rowCount int, metas []ColumnMeta, err error) {
 		if err != nil {
 			return 0, nil, fmt.Errorf("native: column[%d] file: %w", i, err)
 		}
+		if !validDirColumnFile(fileName) {
+			return 0, nil, fmt.Errorf("native: column[%d] invalid file name %q", i, fileName)
+		}
 		metas[i] = ColumnMeta{Index: i, Name: name, Type: chType, file: fileName}
 	}
 	return int(rc), metas, nil
@@ -138,6 +141,17 @@ func readBoundedString(r io.Reader, maxLen int) (string, error) {
 	return string(buf), nil
 }
 
+// validDirColumnFile reports whether name is a safe, plain column file name
+// confined to the dataset directory (no path separators, no traversal, correct
+// suffix). It guards against crafted metadata pointing OpenColumn outside dir.
+func validDirColumnFile(name string) bool {
+	if name == "" || filepath.IsAbs(name) || filepath.Base(name) != name ||
+		strings.ContainsAny(name, `/\`+"\x00") || !strings.HasSuffix(name, dirFileSuffix) {
+		return false
+	}
+	return true
+}
+
 // WriteDir writes each column to its own single-column Native file:
 // col_<NNNNNN>__<name>.native. Files are self-describing and individually readable.
 // A metadata sidecar (metadata.bin) is written after all column files succeed,
@@ -148,10 +162,17 @@ func readBoundedString(r io.Reader, maxLen int) (string, error) {
 // On any error, already-written files are removed (best-effort) before
 // returning, so a failed WriteDir does not leave a half-populated directory.
 func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
+	rowCount := 0
+	if len(cols) > 0 {
+		rowCount = cols[0].NumRow()
+	}
 	seen := make(map[string]struct{}, len(cols))
 	for _, col := range cols {
 		if len(col.Type()) == 0 {
 			return fmt.Errorf("native: column %q has no type; call SetType before writing", col.Name())
+		}
+		if col.NumRow() != rowCount {
+			return fmt.Errorf("native: column %q has %d rows, want %d", col.Name(), col.NumRow(), rowCount)
 		}
 		name := string(col.Name())
 		if _, dup := seen[name]; dup {
@@ -160,6 +181,14 @@ func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
 		seen[name] = struct{}{}
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	// Refuse to overwrite an existing dataset in place: a mid-write failure could
+	// leave stale metadata pointing at replaced/removed column files. Callers that
+	// want to regenerate should write to a fresh directory.
+	if _, err := os.Stat(filepath.Join(dir, dirMetaFile)); err == nil {
+		return fmt.Errorf("native: %s already contains a dataset (%s); write to a fresh directory", dir, dirMetaFile)
+	} else if !os.IsNotExist(err) {
 		return err
 	}
 
@@ -214,10 +243,6 @@ func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
 		return firstErr
 	}
 
-	rowCount := 0
-	if len(cols) > 0 {
-		rowCount = cols[0].NumRow()
-	}
 	if err := writeDirMeta(dir, metas, rowCount); err != nil {
 		for _, p := range written {
 			os.Remove(p)

--- a/format/native_dir.go
+++ b/format/native_dir.go
@@ -1,14 +1,15 @@
 package format
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
-	lz4 "github.com/pierrec/lz4/v4"
 	"github.com/vahid-sohrabloo/chconn/v3/column"
 	"github.com/vahid-sohrabloo/chconn/v3/internal/readerwriter"
 )
@@ -25,7 +26,9 @@ const dirFileSuffix = ".native"
 
 // WriteDir writes each column to its own single-column Native file:
 // col_<NNNNNN>__<name>.native. Files are self-describing and individually readable.
-// Pass WithLZ4() to compress each column file.
+// Pass WithZSTD()/WithLZ4()/WithCodec() to compress each column file.
+// Pass WithConcurrency(n) to control the number of parallel write workers
+// (default: runtime.NumCPU()).
 // On any error, already-written column files are removed (best-effort) before
 // returning, so a failed WriteDir does not leave a half-populated directory.
 func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
@@ -37,18 +40,53 @@ func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	var written []string
+
+	cfg := resolve(opts)
+	workers := cfg.workers()
+	if workers > len(cols) && len(cols) > 0 {
+		workers = len(cols)
+	}
+
+	var (
+		mu       sync.Mutex
+		firstErr error
+		written  []string
+	)
+
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+
 	for i, col := range cols {
-		name := string(col.Name())
-		fn := fmt.Sprintf("col_%06d__%s%s", i, sanitize(name), dirFileSuffix)
-		path := filepath.Join(dir, fn)
-		if err := WriteFile(path, []column.ColumnCore{col}, opts...); err != nil {
-			for _, p := range written {
-				os.Remove(p)
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			name := string(col.Name())
+			fn := fmt.Sprintf("col_%06d__%s%s", i, sanitize(name), dirFileSuffix)
+			path := filepath.Join(dir, fn)
+
+			err := WriteFile(path, []column.ColumnCore{col}, opts...)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("native: write column %q: %w", name, err)
+				}
+			} else {
+				written = append(written, path)
 			}
-			return fmt.Errorf("native: write column %q: %w", name, err)
+		}()
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		for _, p := range written {
+			os.Remove(p)
 		}
-		written = append(written, path)
+		return firstErr
 	}
 	return nil
 }
@@ -64,7 +102,7 @@ type DirReader struct {
 
 // OpenDir scans dir for single-column Native files and reads each file's header
 // to learn name/type/row-count. It does NOT read column data.
-// Pass WithLZ4() if the directory was written with compression.
+// Pass WithZSTD()/WithLZ4()/WithCodec() if the directory was written with compression.
 func OpenDir(dir string, opts ...Option) (*DirReader, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -110,8 +148,15 @@ func readDirFileHeader(path string, opts []Option) (ColumnMeta, int, error) {
 	}
 	defer f.Close()
 	var rd io.Reader = f
-	if cfg.lz4 {
-		rd = lz4.NewReader(f)
+	if cfg.codec != nil {
+		if err := readCompressedHeader(f, cfg.codec.Name); err != nil {
+			return ColumnMeta{}, 0, err
+		}
+		plain, err := readCompressedUnit(f, cfg.codec)
+		if err != nil {
+			return ColumnMeta{}, 0, err
+		}
+		rd = bytes.NewReader(plain)
 	}
 	r := readerwriter.NewReader(rd)
 	numCols, err := r.Uvarint()
@@ -143,7 +188,7 @@ func (dr *DirReader) Columns() []ColumnMeta { return dr.cols }
 func (dr *DirReader) RowCount() int { return dr.rowCount }
 
 // OpenColumn reads ONLY the named column's file and returns its column.
-// The DirReader's own options (e.g. WithLZ4) are applied automatically; any
+// The DirReader's own options (e.g. WithZSTD()/WithLZ4()/WithCodec()) are applied automatically; any
 // opts passed here are appended and may augment or override them.
 func (dr *DirReader) OpenColumn(name string, opts ...Option) (column.ColumnCore, error) {
 	meta, ok := dr.byName[name]
@@ -164,6 +209,51 @@ func (dr *DirReader) OpenColumn(name string, opts ...Option) (column.ColumnCore,
 		return nil, fmt.Errorf("native: column file for %q has no columns", name)
 	}
 	return cols[0], nil
+}
+
+// OpenColumns reads the named columns concurrently (workers from the options
+// OpenDir was created with) and returns them in the same order as names.
+// Each column is read from its own file, so reads are independent.
+// Any opts are passed through to each OpenColumn call and may augment or
+// override the DirReader's own options.
+func (dr *DirReader) OpenColumns(names []string, opts ...Option) ([]column.ColumnCore, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	workers := min(resolve(dr.opts).workers(), len(names))
+
+	type result struct {
+		col column.ColumnCore
+		err error
+	}
+
+	results := make([]result, len(names))
+
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+
+	for i, name := range names {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			col, err := dr.OpenColumn(name, opts...)
+			results[i].col = col
+			results[i].err = err
+		}()
+	}
+	wg.Wait()
+
+	out := make([]column.ColumnCore, len(names))
+	for i, r := range results {
+		if r.err != nil {
+			return nil, r.err
+		}
+		out[i] = r.col
+	}
+	return out, nil
 }
 
 // Close is a no-op (per-column files are opened and closed on demand).

--- a/format/native_dir.go
+++ b/format/native_dir.go
@@ -32,10 +32,16 @@ const dirFileSuffix = ".native"
 // On any error, already-written column files are removed (best-effort) before
 // returning, so a failed WriteDir does not leave a half-populated directory.
 func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
+	seen := make(map[string]struct{}, len(cols))
 	for _, col := range cols {
 		if len(col.Type()) == 0 {
 			return fmt.Errorf("native: column %q has no type; call SetType before writing", col.Name())
 		}
+		name := string(col.Name())
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("native: duplicate column name %q", name)
+		}
+		seen[name] = struct{}{}
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err

--- a/format/native_dir.go
+++ b/format/native_dir.go
@@ -1,17 +1,15 @@
 package format
 
 import (
-	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 
 	"github.com/vahid-sohrabloo/chconn/v3/column"
-	"github.com/vahid-sohrabloo/chconn/v3/internal/readerwriter"
 )
 
 // ColumnMeta describes a column discovered in a dir-mode dataset.
@@ -23,13 +21,131 @@ type ColumnMeta struct {
 }
 
 const dirFileSuffix = ".native"
+const dirMetaFile = "metadata.bin"
+const dirMagic = "CNDM1"
+
+// writeDirMeta writes an uncompressed sidecar file <dir>/metadata.bin with
+// the dataset schema and file mapping. Format:
+//
+//	magic    5 bytes "CNDM1"
+//	uvarint  rowCount
+//	uvarint  numColumns
+//	repeated numColumns:
+//	  uvarint+bytes  name
+//	  uvarint+bytes  chType
+//	  uvarint+bytes  fileName
+//
+// The write is atomic: a temp file is renamed into place on success.
+func writeDirMeta(dir string, metas []ColumnMeta, rowCount int) error {
+	var buf []byte
+	buf = append(buf, dirMagic...)
+	buf = binary.AppendUvarint(buf, uint64(rowCount))
+	buf = binary.AppendUvarint(buf, uint64(len(metas)))
+	for _, m := range metas {
+		buf = binary.AppendUvarint(buf, uint64(len(m.Name)))
+		buf = append(buf, m.Name...)
+		buf = binary.AppendUvarint(buf, uint64(len(m.Type)))
+		buf = append(buf, m.Type...)
+		buf = binary.AppendUvarint(buf, uint64(len(m.file)))
+		buf = append(buf, m.file...)
+	}
+
+	dst := filepath.Join(dir, dirMetaFile)
+	f, err := os.CreateTemp(dir, "."+dirMetaFile+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(buf); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, dst)
+}
+
+// readDirMeta reads the uncompressed sidecar file <dir>/metadata.bin.
+// Returns rowCount, ordered column metas, or an error if the file is missing
+// or corrupt. Bounds: numColumns <= 1<<20, each string field <= 4096 bytes.
+func readDirMeta(dir string) (rowCount int, metas []ColumnMeta, err error) {
+	f, err := os.Open(filepath.Join(dir, dirMetaFile))
+	if err != nil {
+		return 0, nil, err
+	}
+	defer f.Close()
+
+	var magic [5]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return 0, nil, fmt.Errorf("native: read dir metadata magic: %w", err)
+	}
+	if string(magic[:]) != dirMagic {
+		return 0, nil, fmt.Errorf("native: not a chconn dir metadata file (bad magic %v)", magic)
+	}
+
+	rc, err := readUvarint(f)
+	if err != nil {
+		return 0, nil, fmt.Errorf("native: read dir metadata rowCount: %w", err)
+	}
+
+	numCols, err := readUvarint(f)
+	if err != nil {
+		return 0, nil, fmt.Errorf("native: read dir metadata numColumns: %w", err)
+	}
+	if numCols > 1<<20 {
+		return 0, nil, fmt.Errorf("native: dir metadata numColumns %d exceeds limit 1<<20", numCols)
+	}
+
+	metas = make([]ColumnMeta, numCols)
+	for i := range metas {
+		name, err := readBoundedString(f, 4096)
+		if err != nil {
+			return 0, nil, fmt.Errorf("native: column[%d] name: %w", i, err)
+		}
+		chType, err := readBoundedString(f, 4096)
+		if err != nil {
+			return 0, nil, fmt.Errorf("native: column[%d] type: %w", i, err)
+		}
+		fileName, err := readBoundedString(f, 4096)
+		if err != nil {
+			return 0, nil, fmt.Errorf("native: column[%d] file: %w", i, err)
+		}
+		metas[i] = ColumnMeta{Index: i, Name: name, Type: chType, file: fileName}
+	}
+	return int(rc), metas, nil
+}
+
+// readBoundedString reads a uvarint-length-prefixed string from r, rejecting
+// strings longer than maxLen bytes.
+func readBoundedString(r io.Reader, maxLen int) (string, error) {
+	l, err := readUvarint(r)
+	if err != nil {
+		return "", err
+	}
+	if l > uint64(maxLen) {
+		return "", fmt.Errorf("string length %d exceeds limit %d", l, maxLen)
+	}
+	if l == 0 {
+		return "", nil
+	}
+	buf := make([]byte, l)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
 
 // WriteDir writes each column to its own single-column Native file:
 // col_<NNNNNN>__<name>.native. Files are self-describing and individually readable.
+// A metadata sidecar (metadata.bin) is written after all column files succeed,
+// recording the schema without requiring decompression on OpenDir.
 // Pass WithZSTD()/WithLZ4()/WithCodec() to compress each column file.
 // Pass WithConcurrency(n) to control the number of parallel write workers
 // (default: runtime.NumCPU()).
-// On any error, already-written column files are removed (best-effort) before
+// On any error, already-written files are removed (best-effort) before
 // returning, so a failed WriteDir does not leave a half-populated directory.
 func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
 	seen := make(map[string]struct{}, len(cols))
@@ -59,7 +175,9 @@ func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
 		written  []string
 	)
 
-	sem := make(chan struct{}, workers)
+	metas := make([]ColumnMeta, len(cols))
+
+	sem := make(chan struct{}, max(workers, 1))
 	var wg sync.WaitGroup
 
 	for i, col := range cols {
@@ -82,6 +200,7 @@ func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
 					firstErr = fmt.Errorf("native: write column %q: %w", name, err)
 				}
 			} else {
+				metas[i] = ColumnMeta{Index: i, Name: name, Type: string(col.Type()), file: fn}
 				written = append(written, path)
 			}
 		}()
@@ -93,6 +212,17 @@ func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
 			os.Remove(p)
 		}
 		return firstErr
+	}
+
+	rowCount := 0
+	if len(cols) > 0 {
+		rowCount = cols[0].NumRow()
+	}
+	if err := writeDirMeta(dir, metas, rowCount); err != nil {
+		for _, p := range written {
+			os.Remove(p)
+		}
+		return fmt.Errorf("native: write dir metadata: %w", err)
 	}
 	return nil
 }
@@ -106,35 +236,22 @@ type DirReader struct {
 	rowCount int
 }
 
-// OpenDir scans dir for single-column Native files and reads each file's header
-// to learn name/type/row-count. It does NOT read column data.
-// Pass WithZSTD()/WithLZ4()/WithCodec() if the directory was written with compression.
+// OpenDir reads the uncompressed metadata sidecar from dir to learn the
+// dataset schema (column names, types, file mapping, row count). It does NOT
+// read or decompress any column data. The sidecar must have been written by
+// WriteDir; dirs without metadata.bin are rejected.
 func OpenDir(dir string, opts ...Option) (*DirReader, error) {
-	entries, err := os.ReadDir(dir)
+	rowCount, metas, err := readDirMeta(dir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("native: open dir %s: %w", dir, err)
 	}
-	files := make([]string, 0)
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), dirFileSuffix) {
-			files = append(files, e.Name())
-		}
+	dr := &DirReader{
+		dir:      dir,
+		opts:     opts,
+		byName:   make(map[string]ColumnMeta, len(metas)),
+		rowCount: rowCount,
 	}
-	sort.Strings(files) // col_000000__, col_000001__, ... — gives stable column order
-
-	dr := &DirReader{dir: dir, opts: opts, byName: map[string]ColumnMeta{}}
-	for idx, fn := range files {
-		meta, rows, err := readDirFileHeader(filepath.Join(dir, fn), opts)
-		if err != nil {
-			return nil, fmt.Errorf("native: scan %s: %w", fn, err)
-		}
-		meta.Index = idx
-		meta.file = fn
-		if idx == 0 {
-			dr.rowCount = rows
-		} else if rows != dr.rowCount {
-			return nil, fmt.Errorf("native: %s has %d rows, expected %d", fn, rows, dr.rowCount)
-		}
+	for _, meta := range metas {
 		if _, exists := dr.byName[meta.Name]; exists {
 			return nil, fmt.Errorf("native: duplicate column name %q in %s", meta.Name, dir)
 		}
@@ -142,49 +259,6 @@ func OpenDir(dir string, opts ...Option) (*DirReader, error) {
 		dr.byName[meta.Name] = meta
 	}
 	return dr, nil
-}
-
-// readDirFileHeader reads only the block preamble (numCols, numRows) and the
-// first column's name+type from path. No column data is read.
-func readDirFileHeader(path string, opts []Option) (ColumnMeta, int, error) {
-	cfg := resolve(opts)
-	f, err := os.Open(path)
-	if err != nil {
-		return ColumnMeta{}, 0, err
-	}
-	defer f.Close()
-	var rd io.Reader = f
-	if cfg.codec != nil {
-		if err := readCompressedHeader(f, cfg.codec.Name); err != nil {
-			return ColumnMeta{}, 0, err
-		}
-		plain, err := readCompressedUnit(f, cfg.codec)
-		if err != nil {
-			return ColumnMeta{}, 0, err
-		}
-		rd = bytes.NewReader(plain)
-	}
-	r := readerwriter.NewReader(rd)
-	numCols, err := r.Uvarint()
-	if err != nil {
-		return ColumnMeta{}, 0, fmt.Errorf("read num_columns: %w", err)
-	}
-	if numCols != 1 {
-		return ColumnMeta{}, 0, fmt.Errorf("expected 1 column per dir file, got %d", numCols)
-	}
-	numRows, err := r.Uvarint()
-	if err != nil {
-		return ColumnMeta{}, 0, fmt.Errorf("read num_rows: %w", err)
-	}
-	name, err := r.ByteString()
-	if err != nil {
-		return ColumnMeta{}, 0, fmt.Errorf("read column name: %w", err)
-	}
-	chType, err := r.ByteString()
-	if err != nil {
-		return ColumnMeta{}, 0, fmt.Errorf("read column type: %w", err)
-	}
-	return ColumnMeta{Name: string(name), Type: string(chType)}, int(numRows), nil
 }
 
 // Columns returns metadata for every column, in file order.
@@ -236,7 +310,7 @@ func (dr *DirReader) OpenColumns(names []string, opts ...Option) ([]column.Colum
 
 	results := make([]result, len(names))
 
-	sem := make(chan struct{}, workers)
+	sem := make(chan struct{}, max(workers, 1))
 	var wg sync.WaitGroup
 
 	for i, name := range names {

--- a/format/native_dir.go
+++ b/format/native_dir.go
@@ -1,0 +1,180 @@
+package format
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	lz4 "github.com/pierrec/lz4/v4"
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+	"github.com/vahid-sohrabloo/chconn/v3/internal/readerwriter"
+)
+
+// ColumnMeta describes a column discovered in a dir-mode dataset.
+type ColumnMeta struct {
+	Index int
+	Name  string
+	Type  string
+	file  string
+}
+
+const dirFileSuffix = ".native"
+
+// WriteDir writes each column to its own single-column Native file:
+// col_<NNNNNN>__<name>.native. Files are self-describing and individually readable.
+// Pass WithLZ4() to compress each column file.
+// On any error, already-written column files are removed (best-effort) before
+// returning, so a failed WriteDir does not leave a half-populated directory.
+func WriteDir(dir string, cols []column.ColumnCore, opts ...Option) error {
+	for _, col := range cols {
+		if len(col.Type()) == 0 {
+			return fmt.Errorf("native: column %q has no type; call SetType before writing", col.Name())
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	var written []string
+	for i, col := range cols {
+		name := string(col.Name())
+		fn := fmt.Sprintf("col_%06d__%s%s", i, sanitize(name), dirFileSuffix)
+		path := filepath.Join(dir, fn)
+		if err := WriteFile(path, []column.ColumnCore{col}, opts...); err != nil {
+			for _, p := range written {
+				os.Remove(p)
+			}
+			return fmt.Errorf("native: write column %q: %w", name, err)
+		}
+		written = append(written, path)
+	}
+	return nil
+}
+
+// DirReader reads a dir-mode dataset, opening only the columns requested.
+type DirReader struct {
+	dir      string
+	opts     []Option
+	cols     []ColumnMeta
+	byName   map[string]ColumnMeta
+	rowCount int
+}
+
+// OpenDir scans dir for single-column Native files and reads each file's header
+// to learn name/type/row-count. It does NOT read column data.
+// Pass WithLZ4() if the directory was written with compression.
+func OpenDir(dir string, opts ...Option) (*DirReader, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]string, 0)
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), dirFileSuffix) {
+			files = append(files, e.Name())
+		}
+	}
+	sort.Strings(files) // col_000000__, col_000001__, ... — gives stable column order
+
+	dr := &DirReader{dir: dir, opts: opts, byName: map[string]ColumnMeta{}}
+	for idx, fn := range files {
+		meta, rows, err := readDirFileHeader(filepath.Join(dir, fn), opts)
+		if err != nil {
+			return nil, fmt.Errorf("native: scan %s: %w", fn, err)
+		}
+		meta.Index = idx
+		meta.file = fn
+		if idx == 0 {
+			dr.rowCount = rows
+		} else if rows != dr.rowCount {
+			return nil, fmt.Errorf("native: %s has %d rows, expected %d", fn, rows, dr.rowCount)
+		}
+		if _, exists := dr.byName[meta.Name]; exists {
+			return nil, fmt.Errorf("native: duplicate column name %q in %s", meta.Name, dir)
+		}
+		dr.cols = append(dr.cols, meta)
+		dr.byName[meta.Name] = meta
+	}
+	return dr, nil
+}
+
+// readDirFileHeader reads only the block preamble (numCols, numRows) and the
+// first column's name+type from path. No column data is read.
+func readDirFileHeader(path string, opts []Option) (ColumnMeta, int, error) {
+	cfg := resolve(opts)
+	f, err := os.Open(path)
+	if err != nil {
+		return ColumnMeta{}, 0, err
+	}
+	defer f.Close()
+	var rd io.Reader = f
+	if cfg.lz4 {
+		rd = lz4.NewReader(f)
+	}
+	r := readerwriter.NewReader(rd)
+	numCols, err := r.Uvarint()
+	if err != nil {
+		return ColumnMeta{}, 0, fmt.Errorf("read num_columns: %w", err)
+	}
+	if numCols != 1 {
+		return ColumnMeta{}, 0, fmt.Errorf("expected 1 column per dir file, got %d", numCols)
+	}
+	numRows, err := r.Uvarint()
+	if err != nil {
+		return ColumnMeta{}, 0, fmt.Errorf("read num_rows: %w", err)
+	}
+	name, err := r.ByteString()
+	if err != nil {
+		return ColumnMeta{}, 0, fmt.Errorf("read column name: %w", err)
+	}
+	chType, err := r.ByteString()
+	if err != nil {
+		return ColumnMeta{}, 0, fmt.Errorf("read column type: %w", err)
+	}
+	return ColumnMeta{Name: string(name), Type: string(chType)}, int(numRows), nil
+}
+
+// Columns returns metadata for every column, in file order.
+func (dr *DirReader) Columns() []ColumnMeta { return dr.cols }
+
+// RowCount returns the dataset row count.
+func (dr *DirReader) RowCount() int { return dr.rowCount }
+
+// OpenColumn reads ONLY the named column's file and returns its column.
+// The DirReader's own options (e.g. WithLZ4) are applied automatically; any
+// opts passed here are appended and may augment or override them.
+func (dr *DirReader) OpenColumn(name string, opts ...Option) (column.ColumnCore, error) {
+	meta, ok := dr.byName[name]
+	if !ok {
+		return nil, fmt.Errorf("native: column %q not found in %s", name, dr.dir)
+	}
+	allOpts := append(append([]Option(nil), dr.opts...), opts...)
+	fr, err := OpenFile(filepath.Join(dr.dir, meta.file), allOpts...)
+	if err != nil {
+		return nil, err
+	}
+	defer fr.Close()
+	_, cols, err := fr.ReadBlock()
+	if err != nil {
+		return nil, err
+	}
+	if len(cols) == 0 {
+		return nil, fmt.Errorf("native: column file for %q has no columns", name)
+	}
+	return cols[0], nil
+}
+
+// Close is a no-op (per-column files are opened and closed on demand).
+func (dr *DirReader) Close() error { return nil }
+
+// sanitize makes a column name safe for a filename.
+func sanitize(name string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '/' || r == '\\' || r == 0 {
+			return '_'
+		}
+		return r
+	}, name)
+}

--- a/format/native_dir_parallel_test.go
+++ b/format/native_dir_parallel_test.go
@@ -1,0 +1,228 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+// TestWriteDirParallelExplicitConcurrency writes several columns with
+// WithConcurrency(4), then reads each back via OpenColumn and asserts values.
+func TestWriteDirParallelExplicitConcurrency(t *testing.T) {
+	dir := t.TempDir()
+	cols := []column.ColumnCore{
+		floatCol("a", 1.1, 2.2, 3.3),
+		strCol("b", "x", "y", "z"),
+		floatCol("c", 10, 20, 30),
+		floatCol("d", 0.5, 1.5, 2.5),
+		strCol("e", "alpha", "beta", "gamma"),
+	}
+	if err := WriteDir(dir, cols, WithConcurrency(4)); err != nil {
+		t.Fatalf("WriteDir: %v", err)
+	}
+
+	dr, err := OpenDir(dir)
+	if err != nil {
+		t.Fatalf("OpenDir: %v", err)
+	}
+	defer dr.Close()
+
+	if dr.RowCount() != 3 {
+		t.Fatalf("RowCount = %d, want 3", dr.RowCount())
+	}
+	if len(dr.Columns()) != 5 {
+		t.Fatalf("Columns = %d, want 5", len(dr.Columns()))
+	}
+
+	colA, err := dr.OpenColumn("a")
+	if err != nil {
+		t.Fatalf("OpenColumn a: %v", err)
+	}
+	if got := colA.(*column.Base[float64]).Row(1); got != 2.2 {
+		t.Fatalf("a[1] = %v, want 2.2", got)
+	}
+
+	colB, err := dr.OpenColumn("b")
+	if err != nil {
+		t.Fatalf("OpenColumn b: %v", err)
+	}
+	if got := colB.(*column.String).Row(2); got != "z" {
+		t.Fatalf("b[2] = %q, want %q", got, "z")
+	}
+
+	colE, err := dr.OpenColumn("e")
+	if err != nil {
+		t.Fatalf("OpenColumn e: %v", err)
+	}
+	if got := colE.(*column.String).Row(0); got != "alpha" {
+		t.Fatalf("e[0] = %q, want %q", got, "alpha")
+	}
+}
+
+// TestWriteDirParallelDefaultConcurrency uses the default concurrency (NumCPU).
+func TestWriteDirParallelDefaultConcurrency(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{
+		floatCol("p", 7, 8, 9),
+		strCol("q", "one", "two", "three"),
+	}); err != nil {
+		t.Fatalf("WriteDir default concurrency: %v", err)
+	}
+	dr, err := OpenDir(dir)
+	if err != nil {
+		t.Fatalf("OpenDir: %v", err)
+	}
+	defer dr.Close()
+
+	colP, err := dr.OpenColumn("p")
+	if err != nil {
+		t.Fatalf("OpenColumn p: %v", err)
+	}
+	if got := colP.(*column.Base[float64]).Row(0); got != 7 {
+		t.Fatalf("p[0] = %v, want 7", got)
+	}
+}
+
+// TestWriteDirParallelSingleColumn ensures single-column input still works.
+func TestWriteDirParallelSingleColumn(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{
+		floatCol("solo", 42),
+	}, WithConcurrency(4)); err != nil {
+		t.Fatalf("WriteDir single column: %v", err)
+	}
+	dr, err := OpenDir(dir)
+	if err != nil {
+		t.Fatalf("OpenDir: %v", err)
+	}
+	defer dr.Close()
+
+	col, err := dr.OpenColumn("solo")
+	if err != nil {
+		t.Fatalf("OpenColumn: %v", err)
+	}
+	if got := col.(*column.Base[float64]).Row(0); got != 42 {
+		t.Fatalf("solo[0] = %v, want 42", got)
+	}
+}
+
+// TestOpenColumns verifies parallel multi-column read: order matches names,
+// values are correct, and unknown names produce an error.
+func TestOpenColumns(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{
+		floatCol("cpm", 1.5, 2.5, 3.5),
+		strCol("bidder", "a", "bb", "ccc"),
+		floatCol("weight", 10, 20, 30),
+	}); err != nil {
+		t.Fatalf("WriteDir: %v", err)
+	}
+
+	dr, err := OpenDir(dir)
+	if err != nil {
+		t.Fatalf("OpenDir: %v", err)
+	}
+	defer dr.Close()
+
+	// Read a subset in a specific order.
+	cols, err := dr.OpenColumns([]string{"weight", "cpm"})
+	if err != nil {
+		t.Fatalf("OpenColumns: %v", err)
+	}
+	if len(cols) != 2 {
+		t.Fatalf("OpenColumns returned %d cols, want 2", len(cols))
+	}
+	// First result must be "weight".
+	if got := cols[0].(*column.Base[float64]).Row(2); got != 30 {
+		t.Fatalf("weight[2] = %v, want 30", got)
+	}
+	// Second result must be "cpm".
+	if got := cols[1].(*column.Base[float64]).Row(0); got != 1.5 {
+		t.Fatalf("cpm[0] = %v, want 1.5", got)
+	}
+
+	// All three columns.
+	all, err := dr.OpenColumns([]string{"cpm", "bidder", "weight"})
+	if err != nil {
+		t.Fatalf("OpenColumns all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("OpenColumns all returned %d cols, want 3", len(all))
+	}
+	if got := all[1].(*column.String).Row(1); got != "bb" {
+		t.Fatalf("bidder[1] = %q, want %q", got, "bb")
+	}
+
+	// Unknown name must error.
+	if _, err := dr.OpenColumns([]string{"cpm", "nonexistent"}); err == nil {
+		t.Fatal("expected error for unknown column name")
+	}
+}
+
+// TestOpenColumnsEmpty ensures OpenColumns with no names returns nil, nil.
+func TestOpenColumnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{floatCol("v", 1)}); err != nil {
+		t.Fatal(err)
+	}
+	dr, err := OpenDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dr.Close()
+
+	cols, err := dr.OpenColumns(nil)
+	if err != nil {
+		t.Fatalf("OpenColumns empty: %v", err)
+	}
+	if cols != nil {
+		t.Fatalf("expected nil slice for empty names, got %v", cols)
+	}
+}
+
+// TestWriteDirParallelCompressed exercises concurrent codec use:
+// WithZSTD + WithConcurrency(4) then reads back all columns.
+func TestWriteDirParallelCompressed(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{
+		floatCol("cpm", 1.5, 2.5, 3.5),
+		strCol("bidder", "a", "bb", "ccc"),
+		floatCol("weight", 10, 20, 30),
+		strCol("zone", "us", "eu", "ap"),
+	}, WithZSTD(), WithConcurrency(4)); err != nil {
+		t.Fatalf("WriteDir compressed parallel: %v", err)
+	}
+
+	dr, err := OpenDir(dir, WithZSTD())
+	if err != nil {
+		t.Fatalf("OpenDir: %v", err)
+	}
+	defer dr.Close()
+
+	if dr.RowCount() != 3 {
+		t.Fatalf("RowCount = %d, want 3", dr.RowCount())
+	}
+
+	cols, err := dr.OpenColumns([]string{"zone", "cpm", "bidder", "weight"})
+	if err != nil {
+		t.Fatalf("OpenColumns compressed: %v", err)
+	}
+	if got := cols[0].(*column.String).Row(1); got != "eu" {
+		t.Fatalf("zone[1] = %q, want eu", got)
+	}
+	if got := cols[1].(*column.Base[float64]).Row(2); got != 3.5 {
+		t.Fatalf("cpm[2] = %v, want 3.5", got)
+	}
+	if got := cols[2].(*column.String).Row(0); got != "a" {
+		t.Fatalf("bidder[0] = %q, want a", got)
+	}
+	if got := cols[3].(*column.Base[float64]).Row(1); got != 20 {
+		t.Fatalf("weight[1] = %v, want 20", got)
+	}
+}
+
+func TestWriteDirEmpty(t *testing.T) {
+	if err := WriteDir(t.TempDir(), nil); err != nil {
+		t.Fatalf("WriteDir empty: %v", err)
+	}
+}

--- a/format/native_dir_parallel_test.go
+++ b/format/native_dir_parallel_test.go
@@ -226,3 +226,11 @@ func TestWriteDirEmpty(t *testing.T) {
 		t.Fatalf("WriteDir empty: %v", err)
 	}
 }
+
+func TestWriteDirDuplicateName(t *testing.T) {
+	a := floatCol("dup", 1, 2)
+	b := floatCol("dup", 3, 4)
+	if err := WriteDir(t.TempDir(), []column.ColumnCore{a, b}); err == nil {
+		t.Fatal("expected duplicate column name error from WriteDir")
+	}
+}

--- a/format/native_dir_parallel_test.go
+++ b/format/native_dir_parallel_test.go
@@ -222,8 +222,20 @@ func TestWriteDirParallelCompressed(t *testing.T) {
 }
 
 func TestWriteDirEmpty(t *testing.T) {
-	if err := WriteDir(t.TempDir(), nil); err != nil {
+	dir := t.TempDir()
+	if err := WriteDir(dir, nil); err != nil {
 		t.Fatalf("WriteDir empty: %v", err)
+	}
+	dr, err := OpenDir(dir)
+	if err != nil {
+		t.Fatalf("OpenDir on empty dir: %v", err)
+	}
+	defer dr.Close()
+	if dr.RowCount() != 0 {
+		t.Fatalf("RowCount = %d, want 0", dr.RowCount())
+	}
+	if len(dr.Columns()) != 0 {
+		t.Fatalf("Columns = %d, want 0", len(dr.Columns()))
 	}
 }
 

--- a/format/native_dir_test.go
+++ b/format/native_dir_test.go
@@ -1,6 +1,7 @@
 package format
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,5 +62,41 @@ func TestOpenDirCorruptMetadata(t *testing.T) {
 	}
 	if _, err := OpenDir(dir); err == nil {
 		t.Fatal("expected error opening dir with truncated metadata")
+	}
+}
+
+func TestOpenDirRejectsUnsafeFileName(t *testing.T) {
+	dir := t.TempDir()
+	var buf []byte
+	buf = append(buf, "CNDM1"...)
+	buf = binary.AppendUvarint(buf, 1) // rowCount
+	buf = binary.AppendUvarint(buf, 1) // numColumns
+	put := func(s string) { buf = binary.AppendUvarint(buf, uint64(len(s))); buf = append(buf, s...) }
+	put("v")                       // name
+	put("Float64")                 // type
+	put("../../etc/passwd.native") // malicious file mapping
+	if err := os.WriteFile(filepath.Join(dir, "metadata.bin"), buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenDir(dir); err == nil {
+		t.Fatal("expected OpenDir to reject unsafe column file name")
+	}
+}
+
+func TestWriteDirRowCountMismatch(t *testing.T) {
+	a := floatCol("a", 1, 2, 3)
+	b := floatCol("b", 1, 2) // fewer rows
+	if err := WriteDir(t.TempDir(), []column.ColumnCore{a, b}); err == nil {
+		t.Fatal("expected row-count mismatch error from WriteDir")
+	}
+}
+
+func TestWriteDirRefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{floatCol("v", 1, 2)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteDir(dir, []column.ColumnCore{floatCol("v", 3, 4)}); err == nil {
+		t.Fatal("expected WriteDir to refuse overwriting an existing dataset")
 	}
 }

--- a/format/native_dir_test.go
+++ b/format/native_dir_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/vahid-sohrabloo/chconn/v3/column"
@@ -68,18 +69,19 @@ func TestOpenDirCorruptMetadata(t *testing.T) {
 func TestOpenDirRejectsUnsafeFileName(t *testing.T) {
 	dir := t.TempDir()
 	var buf []byte
-	buf = append(buf, "CNDM1"...)
+	buf = append(buf, dirMagic...)
 	buf = binary.AppendUvarint(buf, 1) // rowCount
 	buf = binary.AppendUvarint(buf, 1) // numColumns
 	put := func(s string) { buf = binary.AppendUvarint(buf, uint64(len(s))); buf = append(buf, s...) }
 	put("v")                       // name
 	put("Float64")                 // type
 	put("../../etc/passwd.native") // malicious file mapping
-	if err := os.WriteFile(filepath.Join(dir, "metadata.bin"), buf, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, dirMetaFile), buf, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := OpenDir(dir); err == nil {
-		t.Fatal("expected OpenDir to reject unsafe column file name")
+	// Assert it specifically hit the unsafe-filename guard (not bad magic / missing file).
+	if _, err := OpenDir(dir); err == nil || !strings.Contains(err.Error(), "invalid file name") {
+		t.Fatalf("expected invalid file name error, got %v", err)
 	}
 }
 

--- a/format/native_dir_test.go
+++ b/format/native_dir_test.go
@@ -1,0 +1,44 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+func TestWriteDirAndSelectiveRead(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDir(dir, []column.ColumnCore{
+		floatCol("cpm", 1.5, 2.5, 3.5),
+		strCol("bidder", "a", "bb", "ccc"),
+		floatCol("weight", 10, 20, 30),
+	}); err != nil {
+		t.Fatalf("WriteDir: %v", err)
+	}
+
+	dr, err := OpenDir(dir)
+	if err != nil {
+		t.Fatalf("OpenDir: %v", err)
+	}
+	defer dr.Close()
+
+	if dr.RowCount() != 3 {
+		t.Fatalf("RowCount = %d, want 3", dr.RowCount())
+	}
+	if len(dr.Columns()) != 3 {
+		t.Fatalf("Columns = %d, want 3", len(dr.Columns()))
+	}
+
+	// Open ONLY the "weight" column — selective read.
+	col, err := dr.OpenColumn("weight")
+	if err != nil {
+		t.Fatalf("OpenColumn: %v", err)
+	}
+	if col.(*column.Base[float64]).Row(2) != 30 {
+		t.Fatal("wrong weight value")
+	}
+
+	if _, err := dr.OpenColumn("nope"); err == nil {
+		t.Fatal("expected error for missing column")
+	}
+}

--- a/format/native_dir_test.go
+++ b/format/native_dir_test.go
@@ -1,6 +1,8 @@
 package format
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/vahid-sohrabloo/chconn/v3/column"
@@ -40,5 +42,24 @@ func TestWriteDirAndSelectiveRead(t *testing.T) {
 
 	if _, err := dr.OpenColumn("nope"); err == nil {
 		t.Fatal("expected error for missing column")
+	}
+}
+
+// TestOpenDirMissingMetadata verifies that OpenDir fails when no metadata.bin exists.
+func TestOpenDirMissingMetadata(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := OpenDir(dir); err == nil {
+		t.Fatal("expected error opening dir without metadata.bin")
+	}
+}
+
+func TestOpenDirCorruptMetadata(t *testing.T) {
+	dir := t.TempDir()
+	// Valid magic, then truncated (EOF before rowCount) — must error, not panic.
+	if err := os.WriteFile(filepath.Join(dir, "metadata.bin"), []byte("CNDM1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenDir(dir); err == nil {
+		t.Fatal("expected error opening dir with truncated metadata")
 	}
 }

--- a/format/native_file.go
+++ b/format/native_file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/vahid-sohrabloo/chconn/v3/column"
 )
@@ -58,11 +59,12 @@ func WriteFile(path string, cols []column.ColumnCore, opts ...Option) error {
 		}
 	}
 	cfg := resolve(opts)
-	tmp := path + ".tmp"
-	f, err := os.Create(tmp)
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
 		return err
 	}
+	tmp := f.Name()
 	fail := func(err error) error {
 		f.Close()
 		os.Remove(tmp)

--- a/format/native_file.go
+++ b/format/native_file.go
@@ -1,32 +1,56 @@
 package format
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 
-	lz4 "github.com/pierrec/lz4/v4"
 	"github.com/vahid-sohrabloo/chconn/v3/column"
 )
 
 // FileWriter writes one or more Native-format blocks to an io.Writer.
 type FileWriter struct {
-	nw *NativeWriter
+	w             io.Writer
+	nw            *NativeWriter
+	codec         *Codec
+	headerWritten bool
 }
 
 // NewFileWriter wraps w. WriteBlock may be called repeatedly (multiple blocks).
-func NewFileWriter(w io.Writer) *FileWriter { return &FileWriter{nw: NewNativeWriter(w)} }
+// Pass WithZSTD()/WithLZ4()/WithCodec() to compress each block as a unit.
+func NewFileWriter(w io.Writer, opts ...Option) *FileWriter {
+	cfg := resolve(opts)
+	fw := &FileWriter{w: w, codec: cfg.codec}
+	if cfg.codec == nil {
+		fw.nw = NewNativeWriter(w)
+	}
+	return fw
+}
 
 // WriteBlock writes one block; all columns must have equal NumRow.
 func (fw *FileWriter) WriteBlock(cols ...column.ColumnCore) error {
-	return fw.nw.WriteBlock(cols...)
+	if fw.codec == nil {
+		return fw.nw.WriteBlock(cols...)
+	}
+	if !fw.headerWritten {
+		if err := writeCompressedHeader(fw.w, fw.codec.Name); err != nil {
+			return err
+		}
+		fw.headerWritten = true
+	}
+	var buf bytes.Buffer
+	if err := NewNativeWriter(&buf).WriteBlock(cols...); err != nil {
+		return err
+	}
+	return writeCompressedUnit(fw.w, fw.codec, buf.Bytes())
 }
 
 // WriteFile writes cols as a single-block Native file at path.
 // The write is atomic: data goes to path+".tmp" and is renamed to path only on
 // full success. Any error removes the temp file before returning.
-// Pass WithLZ4() to write an lz4-compressed stream.
+// Pass WithZSTD()/WithLZ4()/WithCodec() to write a compressed file.
 func WriteFile(path string, cols []column.ColumnCore, opts ...Option) error {
 	for _, col := range cols {
 		if len(col.Type()) == 0 {
@@ -39,22 +63,25 @@ func WriteFile(path string, cols []column.ColumnCore, opts ...Option) error {
 	if err != nil {
 		return err
 	}
-	var w io.Writer = f
-	var zw io.Closer
-	if cfg.lz4 {
-		lw := lz4.NewWriter(f)
-		w, zw = lw, lw
-	}
-	if err := NewNativeWriter(w).WriteBlock(cols...); err != nil {
+	fail := func(err error) error {
 		f.Close()
 		os.Remove(tmp)
 		return err
 	}
-	if zw != nil {
-		if err := zw.Close(); err != nil {
-			f.Close()
-			os.Remove(tmp)
-			return err
+	if cfg.codec == nil {
+		if err := NewNativeWriter(f).WriteBlock(cols...); err != nil {
+			return fail(err)
+		}
+	} else {
+		if err := writeCompressedHeader(f, cfg.codec.Name); err != nil {
+			return fail(err)
+		}
+		var buf bytes.Buffer
+		if err := NewNativeWriter(&buf).WriteBlock(cols...); err != nil {
+			return fail(err)
+		}
+		if err := writeCompressedUnit(f, cfg.codec, buf.Bytes()); err != nil {
+			return fail(err)
 		}
 	}
 	if err := f.Close(); err != nil {
@@ -70,24 +97,22 @@ func WriteFile(path string, cols []column.ColumnCore, opts ...Option) error {
 
 // FileReader reads Native-format blocks from a file.
 type FileReader struct {
-	f  *os.File
-	r  io.Reader
-	nr *NativeReader
+	f          *os.File
+	r          io.Reader
+	nr         *NativeReader
+	codec      *Codec
+	headerRead bool
 }
 
 // OpenFile opens a Native file for streaming reads.
-// Pass WithLZ4() to read an lz4-compressed stream.
+// Pass WithZSTD()/WithLZ4()/WithCodec() to read a compressed file.
 func OpenFile(path string, opts ...Option) (*FileReader, error) {
 	cfg := resolve(opts)
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	var r io.Reader = f
-	if cfg.lz4 {
-		r = lz4.NewReader(f)
-	}
-	return &FileReader{f: f, r: r, nr: NewNativeReader()}, nil
+	return &FileReader{f: f, r: f, nr: NewNativeReader(), codec: cfg.codec}, nil
 }
 
 // newReader is a test/helper constructor over an arbitrary io.Reader.
@@ -95,15 +120,43 @@ func newReader(r io.Reader) *FileReader {
 	return &FileReader{r: r, nr: NewNativeReader()}
 }
 
+// readUnit reads (and on first call validates the header of) the next compressed
+// unit, returning its decompressed plaintext. Only valid when codec != nil.
+func (fr *FileReader) readUnit() ([]byte, error) {
+	if !fr.headerRead {
+		if err := readCompressedHeader(fr.r, fr.codec.Name); err != nil {
+			return nil, err
+		}
+		fr.headerRead = true
+	}
+	return readCompressedUnit(fr.r, fr.codec)
+}
+
 // ReadBlock reads the next block, building columns from the file's type strings.
 // Returns io.EOF when no blocks remain.
 func (fr *FileReader) ReadBlock() (int, []column.ColumnCore, error) {
-	cols, err := fr.nr.ReadBlock(fr.r, nil)
-	if errors.Is(err, io.EOF) {
-		return 0, nil, io.EOF
-	}
-	if err != nil {
-		return 0, nil, err
+	var cols []column.ColumnCore
+	if fr.codec == nil {
+		var err error
+		cols, err = fr.nr.ReadBlock(fr.r, nil)
+		if errors.Is(err, io.EOF) {
+			return 0, nil, io.EOF
+		}
+		if err != nil {
+			return 0, nil, err
+		}
+	} else {
+		plain, err := fr.readUnit()
+		if errors.Is(err, io.EOF) {
+			return 0, nil, io.EOF
+		}
+		if err != nil {
+			return 0, nil, err
+		}
+		cols, err = fr.nr.ReadBlock(bytes.NewReader(plain), nil)
+		if err != nil {
+			return 0, nil, err
+		}
 	}
 	numRows := 0
 	if len(cols) > 0 {
@@ -115,12 +168,25 @@ func (fr *FileReader) ReadBlock() (int, []column.ColumnCore, error) {
 // ReadBlockInto reads the next block into caller-provided columns.
 // Returns io.EOF when no blocks remain.
 func (fr *FileReader) ReadBlockInto(cols ...column.ColumnCore) (int, error) {
-	err := fr.nr.ReadBlockInto(fr.r, nil, cols...)
-	if errors.Is(err, io.EOF) {
-		return 0, io.EOF
-	}
-	if err != nil {
-		return 0, err
+	if fr.codec == nil {
+		err := fr.nr.ReadBlockInto(fr.r, nil, cols...)
+		if errors.Is(err, io.EOF) {
+			return 0, io.EOF
+		}
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		plain, err := fr.readUnit()
+		if errors.Is(err, io.EOF) {
+			return 0, io.EOF
+		}
+		if err != nil {
+			return 0, err
+		}
+		if err := fr.nr.ReadBlockInto(bytes.NewReader(plain), nil, cols...); err != nil {
+			return 0, err
+		}
 	}
 	numRows := 0
 	if len(cols) > 0 {

--- a/format/native_file.go
+++ b/format/native_file.go
@@ -1,0 +1,138 @@
+package format
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	lz4 "github.com/pierrec/lz4/v4"
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+// FileWriter writes one or more Native-format blocks to an io.Writer.
+type FileWriter struct {
+	nw *NativeWriter
+}
+
+// NewFileWriter wraps w. WriteBlock may be called repeatedly (multiple blocks).
+func NewFileWriter(w io.Writer) *FileWriter { return &FileWriter{nw: NewNativeWriter(w)} }
+
+// WriteBlock writes one block; all columns must have equal NumRow.
+func (fw *FileWriter) WriteBlock(cols ...column.ColumnCore) error {
+	return fw.nw.WriteBlock(cols...)
+}
+
+// WriteFile writes cols as a single-block Native file at path.
+// The write is atomic: data goes to path+".tmp" and is renamed to path only on
+// full success. Any error removes the temp file before returning.
+// Pass WithLZ4() to write an lz4-compressed stream.
+func WriteFile(path string, cols []column.ColumnCore, opts ...Option) error {
+	for _, col := range cols {
+		if len(col.Type()) == 0 {
+			return fmt.Errorf("native: column %q has no type; call SetType before writing", col.Name())
+		}
+	}
+	cfg := resolve(opts)
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	var w io.Writer = f
+	var zw io.Closer
+	if cfg.lz4 {
+		lw := lz4.NewWriter(f)
+		w, zw = lw, lw
+	}
+	if err := NewNativeWriter(w).WriteBlock(cols...); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if zw != nil {
+		if err := zw.Close(); err != nil {
+			f.Close()
+			os.Remove(tmp)
+			return err
+		}
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// FileReader reads Native-format blocks from a file.
+type FileReader struct {
+	f  *os.File
+	r  io.Reader
+	nr *NativeReader
+}
+
+// OpenFile opens a Native file for streaming reads.
+// Pass WithLZ4() to read an lz4-compressed stream.
+func OpenFile(path string, opts ...Option) (*FileReader, error) {
+	cfg := resolve(opts)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	var r io.Reader = f
+	if cfg.lz4 {
+		r = lz4.NewReader(f)
+	}
+	return &FileReader{f: f, r: r, nr: NewNativeReader()}, nil
+}
+
+// newReader is a test/helper constructor over an arbitrary io.Reader.
+func newReader(r io.Reader) *FileReader {
+	return &FileReader{r: r, nr: NewNativeReader()}
+}
+
+// ReadBlock reads the next block, building columns from the file's type strings.
+// Returns io.EOF when no blocks remain.
+func (fr *FileReader) ReadBlock() (int, []column.ColumnCore, error) {
+	cols, err := fr.nr.ReadBlock(fr.r, nil)
+	if errors.Is(err, io.EOF) {
+		return 0, nil, io.EOF
+	}
+	if err != nil {
+		return 0, nil, err
+	}
+	numRows := 0
+	if len(cols) > 0 {
+		numRows = cols[0].NumRow()
+	}
+	return numRows, cols, nil
+}
+
+// ReadBlockInto reads the next block into caller-provided columns.
+// Returns io.EOF when no blocks remain.
+func (fr *FileReader) ReadBlockInto(cols ...column.ColumnCore) (int, error) {
+	err := fr.nr.ReadBlockInto(fr.r, nil, cols...)
+	if errors.Is(err, io.EOF) {
+		return 0, io.EOF
+	}
+	if err != nil {
+		return 0, err
+	}
+	numRows := 0
+	if len(cols) > 0 {
+		numRows = cols[0].NumRow()
+	}
+	return numRows, nil
+}
+
+// Close closes the underlying file (nil for reader-backed instances).
+func (fr *FileReader) Close() error {
+	if fr.f == nil {
+		return nil
+	}
+	return fr.f.Close()
+}

--- a/format/native_file_test.go
+++ b/format/native_file_test.go
@@ -1,0 +1,95 @@
+package format
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+func TestWriteAndOpenFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.native")
+	if err := WriteFile(path, []column.ColumnCore{
+		floatCol("cpm", 1.5, 2.5),
+		strCol("bidder", "x", "yy"),
+	}); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	fr, err := OpenFile(path)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer fr.Close()
+
+	numRows, cols, err := fr.ReadBlock()
+	if err != nil {
+		t.Fatalf("ReadBlock: %v", err)
+	}
+	if numRows != 2 || len(cols) != 2 {
+		t.Fatalf("got numRows=%d cols=%d", numRows, len(cols))
+	}
+	if cols[0].(*column.Base[float64]).Row(1) != 2.5 {
+		t.Fatal("wrong float value")
+	}
+	if cols[1].(*column.String).Row(0) != "x" || cols[1].(*column.String).Row(1) != "yy" {
+		t.Fatal("wrong string value")
+	}
+}
+
+func TestFileReaderReadBlockIntoEOF(t *testing.T) {
+	var buf bytes.Buffer
+	fw := NewFileWriter(&buf)
+	if err := fw.WriteBlock(floatCol("v", 1, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := fw.WriteBlock(floatCol("v", 3)); err != nil {
+		t.Fatal(err)
+	}
+	fr := newReader(&buf)
+	total := 0
+	for {
+		n, err := fr.ReadBlockInto(floatCol("v"))
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("ReadBlockInto: %v", err)
+		}
+		total += n
+	}
+	if total != 3 {
+		t.Fatalf("total rows = %d, want 3", total)
+	}
+}
+
+func TestFileWriterMultiBlock(t *testing.T) {
+	var buf bytes.Buffer
+	fw := NewFileWriter(&buf)
+	if err := fw.WriteBlock(floatCol("v", 1, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := fw.WriteBlock(floatCol("v", 3, 4, 5)); err != nil {
+		t.Fatal(err)
+	}
+
+	r := newReader(&buf)
+	total := 0
+	for {
+		n, cols, err := r.ReadBlock()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("ReadBlock: %v", err)
+		}
+		total += n
+		_ = cols
+	}
+	if total != 5 {
+		t.Fatalf("total rows = %d, want 5", total)
+	}
+}

--- a/format/native_interop_test.go
+++ b/format/native_interop_test.go
@@ -1,0 +1,55 @@
+package format
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vahid-sohrabloo/chconn/v3/column"
+)
+
+func clickhouseBin(t *testing.T) string {
+	for _, name := range []string{"clickhouse-local", "clickhouse"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p
+		}
+	}
+	t.Skip("clickhouse-local not found; skipping interop test")
+	return ""
+}
+
+// Write a Native file here, then have ClickHouse read it and emit TSV.
+func TestInteropClickHouseReadsOurNative(t *testing.T) {
+	bin := clickhouseBin(t)
+	path := filepath.Join(t.TempDir(), "out.native")
+	if err := WriteFile(path, []column.ColumnCore{
+		floatCol("cpm", 1.5, 2.5),
+		strCol("bidder", "alpha", "beta"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	args := []string{}
+	if strings.HasSuffix(bin, "clickhouse") {
+		args = append(args, "local")
+	}
+	args = append(args,
+		"--query",
+		"SELECT cpm, bidder FROM file('"+path+"', Native, 'cpm Float64, bidder String') ORDER BY cpm FORMAT TSV",
+	)
+	var out bytes.Buffer
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("clickhouse read failed: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	want := "1.5\talpha\n2.5\tbeta"
+	if got != want {
+		t.Fatalf("interop mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/format/native_options.go
+++ b/format/native_options.go
@@ -1,16 +1,31 @@
 package format
 
+import "runtime"
+
 // config holds resolved writer/reader options.
 type config struct {
-	lz4 bool
+	codec       *Codec
+	concurrency int
 }
 
 // Option configures native readers/writers.
 type Option func(*config)
 
-// WithLZ4 stores/reads the file as an lz4-compressed stream. Incompatible with
-// zero-copy (BytesReader); use the streaming OpenFile path with this option.
-func WithLZ4() Option { return func(c *config) { c.lz4 = true } }
+// WithZSTD stores/reads the file as zstd-compressed per-block units. Incompatible
+// with zero-copy (BytesReader); use the streaming OpenFile path with this option.
+func WithZSTD() Option { return func(c *config) { c.codec = zstdCodec() } }
+
+// WithLZ4 stores/reads the file as lz4-compressed per-block units. Incompatible
+// with zero-copy (BytesReader); use the streaming OpenFile path with this option.
+func WithLZ4() Option { return func(c *config) { c.codec = lz4Codec() } }
+
+// WithCodec stores/reads the file using a custom pluggable codec. Incompatible
+// with zero-copy (BytesReader); use the streaming OpenFile path with this option.
+func WithCodec(codec Codec) Option { return func(c *config) { cc := codec; c.codec = &cc } }
+
+// WithConcurrency sets the number of worker goroutines for parallel dir-mode
+// writes and reads. n <= 0 uses runtime.NumCPU().
+func WithConcurrency(n int) Option { return func(c *config) { c.concurrency = n } }
 
 func resolve(opts []Option) config {
 	var c config
@@ -18,4 +33,13 @@ func resolve(opts []Option) config {
 		o(&c)
 	}
 	return c
+}
+
+// workers returns the effective worker count: the configured value if positive,
+// otherwise runtime.NumCPU().
+func (c config) workers() int {
+	if c.concurrency > 0 {
+		return c.concurrency
+	}
+	return runtime.NumCPU()
 }

--- a/format/native_options.go
+++ b/format/native_options.go
@@ -1,0 +1,21 @@
+package format
+
+// config holds resolved writer/reader options.
+type config struct {
+	lz4 bool
+}
+
+// Option configures native readers/writers.
+type Option func(*config)
+
+// WithLZ4 stores/reads the file as an lz4-compressed stream. Incompatible with
+// zero-copy (BytesReader); use the streaming OpenFile path with this option.
+func WithLZ4() Option { return func(c *config) { c.lz4 = true } }
+
+func resolve(opts []Option) config {
+	var c config
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/kelindar/bitmap v1.5.2
-	github.com/klauspost/compress v1.18.0
+	github.com/klauspost/compress v1.18.6
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/tools v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/kelindar/bitmap v1.5.2 h1:XwX7CTvJtetQZ64zrOkApoZZHBJRkjE23NfqUALA/HE
 github.com/kelindar/bitmap v1.5.2/go.mod h1:j3qZjxH9s4OtvsnFTP2bmPkjqil9Y2xQlxPYHexasEA=
 github.com/kelindar/simd v1.1.2 h1:KduKb+M9cMY2HIH8S/cdJyD+5n5EGgq+Aeeleos55To=
 github.com/kelindar/simd v1.1.2/go.mod h1:inq4DFudC7W8L5fhxoeZflLRNpWSs0GNx6MlWFvuvr0=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=

--- a/shared/server_info.go
+++ b/shared/server_info.go
@@ -16,6 +16,7 @@ type ServerInfo struct {
 	Timezone           string
 	PasswordPatterns   []ServerInfoPasswordRules
 }
+
 // ServerInfoPasswordRules contains a regex pattern and message for server-side password validation.
 type ServerInfoPasswordRules struct {
 	Pattern string


### PR DESCRIPTION
## Summary

Adds file/directory persistence and a zero-copy reader for ClickHouse **Native format**, built on the existing `format.NativeWriter`/`NativeReader` block core (no duplication). Output is byte-identical to `clickhouse-local --format Native`.

### `column` package
- New optional `ZeroCopyColumn` interface + `ReadFromBytes` on `Base[T]` and `String`.
  - amd64/arm64: aliases the caller's buffer via `unsafe.Slice` (no copy / no alloc).
  - other arches: copy + per-element byte-swap on big-endian.
  - overflow-safe bounds checks; aliased columns are read-only (documented).
- Additive only — `ColumnCore` is unchanged.

### `format` package
- **File mode** — `WriteFile`/`OpenFile`/`FileReader`: single Native file, atomic temp+rename write, multi-block streaming.
- **Dir mode** — `WriteDir`/`OpenDir`/`OpenColumn`: one single-column Native file per column, selective per-column reads via a lightweight header-only scan.
- **Zero-copy** — `BytesReader`/`OpenBytes`: reads aliasing a caller-owned buffer (e.g. an mmap). ~constant allocations regardless of column size.
- **`WithLZ4()`** — optional lz4 compression (forces the streaming path).
- `maxColumns` DoS guard on `ReadBlock`/`ReadBlockInto`.

### Incidental fixes
- Fixes a pre-existing **big-endian compile error** in `base_big_cpu.go` (`readBufferHook` referenced removed struct fields).
- Tidies a `//nolint` directive placement in `column_helper.go`.

## Testing
- Full `format` suite passes, including a **live `clickhouse-local` interop round-trip** (proves byte-compatibility with real ClickHouse).
- Zero-copy column tests pass; benchmark shows constant ~3 allocs/op for a 100k-row float column.
- Cross-builds on **amd64, arm64, and s390x** (big-endian).
- `gofmt` and `go vet` clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Native format support for streaming single files, directory-based datasets, and byte-backed block reading.
  * Introduced `ZeroCopyColumn`/`ReadFromBytes` to enable zero-copy column loading when supported.
  * Added pluggable Native compression (ZSTD/LZ4/custom) with configurable concurrency.

* **Bug Fixes**
  * Added stronger validation to reject implausible column counts and malformed/truncated Native data, including improved EOF behavior and clearer errors.

* **Tests**
  * Expanded coverage for Native round-trips, directory parallelism, compression, boundary/error cases, and ClickHouse interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->